### PR TITLE
Adding tests to ensure that gradle builds the jmeter jars correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   only:
     - master
     - development
-    - travis-further-integration
+    - jmeter-build-steps
     - couchbase-provider
 services:
   - rabbitmq

--- a/jmeter/build.gradle
+++ b/jmeter/build.gradle
@@ -44,6 +44,7 @@ task pluginSupportJar(type: Zip) {
     exclude "xmpcore-*.*"
     exclude "xpp*.*"
     exclude "xstream-*.*"
+    exclude "mache*.*"
 }
 
 task pluginJar(type: Jar, dependsOn: compileJava) {

--- a/jmeter/build.gradle
+++ b/jmeter/build.gradle
@@ -96,6 +96,7 @@ assemble.dependsOn pluginSupportJar
 
 compileJava {
     doLast {
+        /* this is required for travis */
         println "Building JMeter JARs..."
         pluginJar.execute()
         pluginSupportJar.execute()

--- a/jmeter/build.gradle
+++ b/jmeter/build.gradle
@@ -53,6 +53,7 @@ task pluginJar(type: Jar, dependsOn: compileJava) {
     */
     println "Mongo:" + project(':mache-mongo').sourceSets.main.output.classesDir
     println "Cassandra:" + project(':mache-cassandra').sourceSets.main.output.classesDir
+    println "RabbitMQ:" + project(':mache-rabbit').sourceSets.main.output.classesDir
 
 
     manifest {
@@ -64,15 +65,23 @@ task pluginJar(type: Jar, dependsOn: compileJava) {
     from sourceSets.main.output.classesDir
     include '**/*.class'
 
-    from project(':mache-observable').sourceSets.main.output.classesDir
-    include '**/*.class'
-
-    from project(':mache-activemq').sourceSets.main.output.classesDir
-    include '**/*.class'
-
     from project(':mache-core').sourceSets.main.output.classesDir
     include '**/*.class'
 
+    from project(':mache-observable').sourceSets.main.output.classesDir
+    include '**/*.class'
+
+    /*Messaging*/
+    from project(':mache-activemq').sourceSets.main.output.classesDir
+    include '**/*.class'
+
+    from project(':mache-rabbit').sourceSets.main.output.classesDir
+    include '**/*.class'
+
+    from project(':mache-kafka').sourceSets.main.output.classesDir
+    include '**/*.class'
+
+    /*Persistence*/
     from project(':mache-mongo').sourceSets.main.output.classesDir
     include '**/*.class'
 
@@ -87,6 +96,9 @@ assemble.dependsOn pluginSupportJar
 
 dependencies {
     compile project(':mache-activemq')
+    compile project(':mache-rabbit')
+    compile project(':mache-kafka')
+
     compile project(':mache-mongo')
     compile project(':mache-observable')
     compile project(':mache-core')
@@ -95,5 +107,4 @@ dependencies {
 
     compile 'org.apache.jmeter:ApacheJMeter_java:2.11' // 2.11 and jcenter compiles ok
     compile 'commons-logging:commons-logging:1.1.1'
-
 }

--- a/jmeter/build.gradle
+++ b/jmeter/build.gradle
@@ -94,6 +94,15 @@ task pluginJar(type: Jar, dependsOn: compileJava) {
 assemble.dependsOn pluginJar
 assemble.dependsOn pluginSupportJar
 
+compileJava {
+    doLast {
+        println "Building JMeter JARs..."
+        pluginJar.execute()
+        pluginSupportJar.execute()
+    }
+}
+
+
 dependencies {
     compile project(':mache-activemq')
     compile project(':mache-rabbit')

--- a/jmeter/build.gradle
+++ b/jmeter/build.gradle
@@ -50,7 +50,6 @@ task pluginJar(type: Jar, dependsOn: compileJava) {
     /*
      Builds the jar to be copied to JMETER/lib/ext folder
     */
-
     println "Mongo:" + project(':mache-mongo').sourceSets.main.output.classesDir
     println "Cassandra:" + project(':mache-cassandra').sourceSets.main.output.classesDir
 
@@ -82,6 +81,8 @@ task pluginJar(type: Jar, dependsOn: compileJava) {
     include '**/*.class'
 }
 
+assemble.dependsOn pluginJar
+assemble.dependsOn pluginSupportJar
 
 dependencies {
     compile project(':mache-activemq')

--- a/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
+++ b/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
@@ -1,6 +1,4 @@
 package com.excelian.mache.jmeter;
-
-import com.drew.metadata.Directory;
 import com.excelian.mache.cassandra.CassandraCacheLoader;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.events.integration.ActiveMQFactory;
@@ -8,6 +6,7 @@ import com.excelian.mache.events.integration.KafkaMQFactory;
 import com.excelian.mache.events.integration.RabbitMQFactory;
 import com.excelian.mache.mongo.MongoDBCacheLoader;
 import com.excelian.mache.observable.ObservableCacheFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -23,29 +22,11 @@ public class JMeterJarTest {
     public static final String MAIN_PLUGIN_JAR_PATH = "./build/libs/jmeter-mache-plugin-0.1-SNAPSHOT.jar";
     public static final String SUPPORT_JAR_PATH = "./build/distributions/jmeter-mache-plugin-support-all-0.1-SNAPSHOT-src.zip";
 
-
-    public void printFnames(String sDir){
-        File[] faFiles = new File(sDir).listFiles();
-        for(File file: faFiles){
-            if(file.getName().matches("^(.*?)")){
-                System.out.println(file.getAbsolutePath());
-            }
-            if(file.isDirectory()){
-                printFnames(file.getAbsolutePath());
-            }
-        }
-    }
-
-    @Test
-    public void DumpDirectoryTree(){
-        printFnames(".");
-    }
-
     @Test
     public void JmeterMachePluginDirectoryExists(){
 
         File f = new File(new File(MAIN_PLUGIN_JAR_PATH).getParent());
-        assertTrue("Expected the plugin directory to exist "+f.getAbsolutePath(), f.exists());
+        assertTrue("Expected the plugin directory to exist " + f.getAbsolutePath(), f.exists());
     }
 
     @Test
@@ -103,13 +84,21 @@ public class JMeterJarTest {
     }
 
     @Test
+    public void JmeterMacheSupportJarShouldNotBeEmpty() throws IOException {
+
+        File f = new File(SUPPORT_JAR_PATH);
+        JarFile jarFile = new JarFile(f.getAbsolutePath());
+        assertTrue(jarFile.size()>0);
+    }
+
+    @Test
     public void TheJmeterMacheSupportJarShouldNotContainMacheJars() throws IOException {
 
         File f = new File(SUPPORT_JAR_PATH);
         JarFile jarFile = new JarFile(f.getAbsolutePath());
 
         Enumeration<JarEntry> entries = jarFile.entries();
-
+        
         while (entries.hasMoreElements()) {
             final JarEntry entry = entries.nextElement();
             final String entryName = entry.getName();
@@ -127,5 +116,23 @@ public class JMeterJarTest {
     {
         String filePath = cls.getCanonicalName().replace('.', '/');
         assertItemIsPresentWithinJar(jarFile, filePath + ".class");
+    }
+
+    @Test
+    @Ignore
+    public void DumpDirectoryTreeToDebugTravis(){
+        printFnames(".");
+    }
+
+    public void printFnames(String sDir){
+        File[] faFiles = new File(sDir).listFiles();
+        for(File file: faFiles){
+            if(file.getName().matches("^(.*?)")){
+                System.out.println(file.getAbsolutePath());
+            }
+            if(file.isDirectory()){
+                printFnames(file.getAbsolutePath());
+            }
+        }
     }
 }

--- a/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
+++ b/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
@@ -1,5 +1,12 @@
 package com.excelian.mache.jmeter;
 
+import com.excelian.mache.cassandra.CassandraCacheLoader;
+import com.excelian.mache.core.Mache;
+import com.excelian.mache.events.integration.ActiveMQFactory;
+import com.excelian.mache.events.integration.KafkaMQFactory;
+import com.excelian.mache.events.integration.RabbitMQFactory;
+import com.excelian.mache.mongo.MongoDBCacheLoader;
+import com.excelian.mache.observable.ObservableCacheFactory;
 import org.junit.Test;
 
 import java.io.File;
@@ -15,6 +22,14 @@ public class JMeterJarTest {
     public static final String MAIN_PLUGIN_JAR_PATH = "./build/libs/jmeter-mache-plugin-0.1-SNAPSHOT.jar";
     public static final String SUPPORT_JAR_PATH = "./build/distributions/jmeter-mache-plugin-support-all-0.1-SNAPSHOT-src.zip";
 
+
+    @Test
+    public void JmeterMachePluginDirectoryExists(){
+
+        File f = new File(new File(MAIN_PLUGIN_JAR_PATH).getParent());
+        assertTrue("Expected the plugin directory to exist "+f.getAbsolutePath(), f.exists());
+    }
+
     @Test
     public void JmeterMachePluginJarShouldBeBuilt(){
 
@@ -26,7 +41,51 @@ public class JMeterJarTest {
     public void JmeterMachePluginJarMustContainAManifest() throws IOException {
 
         JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
-        assertNotNull(jarFile.getJarEntry("META-INF/MANIFEST.MF"));
+        assertFileIsPresentWithinJar(jarFile, "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    public void JmeterMachePluginJarContainsTheExpectedCoreFiles() throws IOException {
+        JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
+
+        assertFileIsPresentWithinJar(jarFile, MacheAbstractJavaSamplerClient.class);
+        assertFileIsPresentWithinJar(jarFile, Mache.class);
+        assertFileIsPresentWithinJar(jarFile, ObservableCacheFactory.class);
+    }
+
+    @Test
+    public void JmeterMachePluginJarContainsTheDatabaseIntegrationFiles() throws IOException {
+        JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
+
+        assertFileIsPresentWithinJar(jarFile, CassandraCacheLoader.class);
+        assertFileIsPresentWithinJar(jarFile,MongoDBCacheLoader.class);
+    }
+
+    @Test
+    public void JmeterMachePluginJarContainsTheExpectedMessagingIntegrationClasses() throws IOException {
+        JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
+
+        assertFileIsPresentWithinJar(jarFile, ActiveMQFactory.class);
+        assertFileIsPresentWithinJar(jarFile, RabbitMQFactory.class);
+        assertFileIsPresentWithinJar(jarFile, KafkaMQFactory.class);
+    }
+
+    private void assertFileIsPresentWithinJar(JarFile jarFile, String filePath)
+    {
+        assertNotNull("Expected " + filePath + " to be present within " + jarFile.getName(), jarFile.getJarEntry(filePath));
+    }
+
+    private void assertFileIsPresentWithinJar(JarFile jarFile, Class cls)
+    {
+        String filePath = cls.getCanonicalName().replace('.', '/');
+        assertFileIsPresentWithinJar(jarFile, filePath + ".class");
+    }
+
+    @Test
+    public void JmeterMachePluginSupportDirectoryExists(){
+
+        File f = new File(new File(SUPPORT_JAR_PATH).getParent());
+        assertTrue("Expected the plugin directory to exist " + f.getAbsolutePath(), f.exists());
     }
 
     @Test
@@ -48,7 +107,7 @@ public class JMeterJarTest {
             final JarEntry entry = entries.nextElement();
             final String entryName = entry.getName();
 
-            assertFalse("Jar should not contain mache code but contains "+entryName, entryName.contains("mache"));
+            assertFalse("Jar should not contain mache code but contains " + entryName, entryName.contains("mache"));
         }
     }
 }

--- a/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
+++ b/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.jmeter;
 
+import com.drew.metadata.Directory;
 import com.excelian.mache.cassandra.CassandraCacheLoader;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.events.integration.ActiveMQFactory;
@@ -23,6 +24,23 @@ public class JMeterJarTest {
     public static final String SUPPORT_JAR_PATH = "./build/distributions/jmeter-mache-plugin-support-all-0.1-SNAPSHOT-src.zip";
 
 
+    public void printFnames(String sDir){
+        File[] faFiles = new File(sDir).listFiles();
+        for(File file: faFiles){
+            if(file.getName().matches("^(.*?)")){
+                System.out.println(file.getAbsolutePath());
+            }
+            if(file.isDirectory()){
+                printFnames(file.getAbsolutePath());
+            }
+        }
+    }
+
+    @Test
+    public void DumpDirectoryTree(){
+        printFnames(".");
+    }
+
     @Test
     public void JmeterMachePluginDirectoryExists(){
 
@@ -41,44 +59,33 @@ public class JMeterJarTest {
     public void JmeterMachePluginJarMustContainAManifest() throws IOException {
 
         JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
-        assertFileIsPresentWithinJar(jarFile, "META-INF/MANIFEST.MF");
+        assertItemIsPresentWithinJar(jarFile, "META-INF/MANIFEST.MF");
     }
 
     @Test
     public void JmeterMachePluginJarContainsTheExpectedCoreFiles() throws IOException {
         JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
 
-        assertFileIsPresentWithinJar(jarFile, MacheAbstractJavaSamplerClient.class);
-        assertFileIsPresentWithinJar(jarFile, Mache.class);
-        assertFileIsPresentWithinJar(jarFile, ObservableCacheFactory.class);
+        assertItemIsPresentWithinJar(jarFile, MacheAbstractJavaSamplerClient.class);
+        assertItemIsPresentWithinJar(jarFile, Mache.class);
+        assertItemIsPresentWithinJar(jarFile, ObservableCacheFactory.class);
     }
 
     @Test
     public void JmeterMachePluginJarContainsTheDatabaseIntegrationFiles() throws IOException {
         JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
 
-        assertFileIsPresentWithinJar(jarFile, CassandraCacheLoader.class);
-        assertFileIsPresentWithinJar(jarFile,MongoDBCacheLoader.class);
+        assertItemIsPresentWithinJar(jarFile, CassandraCacheLoader.class);
+        assertItemIsPresentWithinJar(jarFile, MongoDBCacheLoader.class);
     }
 
     @Test
     public void JmeterMachePluginJarContainsTheExpectedMessagingIntegrationClasses() throws IOException {
         JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
 
-        assertFileIsPresentWithinJar(jarFile, ActiveMQFactory.class);
-        assertFileIsPresentWithinJar(jarFile, RabbitMQFactory.class);
-        assertFileIsPresentWithinJar(jarFile, KafkaMQFactory.class);
-    }
-
-    private void assertFileIsPresentWithinJar(JarFile jarFile, String filePath)
-    {
-        assertNotNull("Expected " + filePath + " to be present within " + jarFile.getName(), jarFile.getJarEntry(filePath));
-    }
-
-    private void assertFileIsPresentWithinJar(JarFile jarFile, Class cls)
-    {
-        String filePath = cls.getCanonicalName().replace('.', '/');
-        assertFileIsPresentWithinJar(jarFile, filePath + ".class");
+        assertItemIsPresentWithinJar(jarFile, ActiveMQFactory.class);
+        assertItemIsPresentWithinJar(jarFile, RabbitMQFactory.class);
+        assertItemIsPresentWithinJar(jarFile, KafkaMQFactory.class);
     }
 
     @Test
@@ -92,7 +99,7 @@ public class JMeterJarTest {
     public void JmeterMacheSupportJarShouldBeBuilt(){
 
         File f = new File(SUPPORT_JAR_PATH);
-        assertTrue("Expected the plugin support jar to have been built at location "+f.getAbsolutePath(), f.exists());
+        assertTrue("Expected the plugin support jar to have been built at location " + f.getAbsolutePath(), f.exists());
     }
 
     @Test
@@ -109,5 +116,16 @@ public class JMeterJarTest {
 
             assertFalse("Jar should not contain mache code but contains " + entryName, entryName.contains("mache"));
         }
+    }
+
+    private void assertItemIsPresentWithinJar(JarFile jarFile, String filePath)
+    {
+        assertNotNull("Expected " + filePath + " to be present within " + jarFile.getName(), jarFile.getJarEntry(filePath));
+    }
+
+    private void assertItemIsPresentWithinJar(JarFile jarFile, Class cls)
+    {
+        String filePath = cls.getCanonicalName().replace('.', '/');
+        assertItemIsPresentWithinJar(jarFile, filePath + ".class");
     }
 }

--- a/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
+++ b/jmeter/src/test/java/com/excelian/mache/jmeter/JMeterJarTest.java
@@ -1,0 +1,54 @@
+package com.excelian.mache.jmeter;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import static org.junit.Assert.*;
+
+public class JMeterJarTest {
+
+    public static final String MAIN_PLUGIN_JAR_PATH = "./build/libs/jmeter-mache-plugin-0.1-SNAPSHOT.jar";
+    public static final String SUPPORT_JAR_PATH = "./build/distributions/jmeter-mache-plugin-support-all-0.1-SNAPSHOT-src.zip";
+
+    @Test
+    public void JmeterMachePluginJarShouldBeBuilt(){
+
+        File f = new File(MAIN_PLUGIN_JAR_PATH);
+        assertTrue("Expected the plugin jar to have been built at location "+f.getAbsolutePath(), f.exists());
+    }
+
+    @Test
+    public void JmeterMachePluginJarMustContainAManifest() throws IOException {
+
+        JarFile jarFile = new JarFile(MAIN_PLUGIN_JAR_PATH);
+        assertNotNull(jarFile.getJarEntry("META-INF/MANIFEST.MF"));
+    }
+
+    @Test
+    public void JmeterMacheSupportJarShouldBeBuilt(){
+
+        File f = new File(SUPPORT_JAR_PATH);
+        assertTrue("Expected the plugin support jar to have been built at location "+f.getAbsolutePath(), f.exists());
+    }
+
+    @Test
+    public void TheJmeterMacheSupportJarShouldNotContainMacheJars() throws IOException {
+
+        File f = new File(SUPPORT_JAR_PATH);
+        JarFile jarFile = new JarFile(f.getAbsolutePath());
+
+        Enumeration<JarEntry> entries = jarFile.entries();
+
+        while (entries.hasMoreElements()) {
+            final JarEntry entry = entries.nextElement();
+            final String entryName = entry.getName();
+
+            assertFalse("Jar should not contain mache code but contains "+entryName, entryName.contains("mache"));
+        }
+    }
+}


### PR DESCRIPTION
Adding tests to ensure that gradle builds the jmeter jars correctly so that we get a build failure if a refactoring breaks their generation.
