### PR TITLE
Couchprovcleanup : Storage Provisioners now share a connection context - this necessary for Cassandra and Mache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - gradle check
   - gradle :mache-example:putClient -Parg=10,Cassandra,localhost
   - gradle :mache-example:putClient -Parg=10,Mongo,localhost
-  - gradle :mache-example:putClient -Parg=10,Couchbase,localhost
+#  - gradle :mache-example:putClient -Parg=10,Couchbase,localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ cache:
   directories:
     - ~/.gradle
     - ~/binaries
+
+script:
+  - gradle check
+  - gradle :mache-example:putClient -Parg=10,Cassandra,localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,5 @@ script:
   - gradle check
   - gradle :mache-example:putClient -Parg=10,Cassandra,localhost
   - gradle :mache-example:putClient -Parg=10,Mongo,localhost
-  - gradle :mache-example:putClient -Parg=10,Couchbase,127.0.0.1
+  - gradle :mache-example:putClient -Parg=10,Couchbase,localhost
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ cache:
 script:
   - gradle check
   - gradle :mache-example:putClient -Parg=10,Cassandra,localhost
+  - gradle :mache-example:putClient -Parg=10,Mongo,localhost
+  - gradle :mache-example:putClient -Parg=10,Couchbase,localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - gradle check
   - gradle :mache-example:putClient -Parg=10,Cassandra,localhost
   - gradle :mache-example:putClient -Parg=10,Mongo,localhost
-#  - gradle :mache-example:putClient -Parg=10,Couchbase,localhost
+  - gradle :mache-example:putClient -Parg=10,Couchbase,127.0.0.1

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/AbstractCassandraSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/AbstractCassandraSamplerClient.java
@@ -7,23 +7,23 @@ import com.excelian.mache.jmeter.MacheAbstractJavaSamplerClient;
 
 @SuppressWarnings("serial")
 public abstract class AbstractCassandraSamplerClient extends MacheAbstractJavaSamplerClient {
-	@Override
-	public void setupTest(JavaSamplerContext context) {
-		getLogger().info("mache setupTest started  \n");
-		//extractParameters(context);
-		getLogger().info("mache setupTest completed. ");
-	}
-	
-	@Override
-	public void teardownTest(JavaSamplerContext context) {
-	}
-	
-	@Override
-	public Arguments getDefaultParameters() {
-		Arguments defaultParameters = new Arguments();
-		defaultParameters.addArgument("cassandra.server.ip.address", "192.168.1.18");
-		defaultParameters.addArgument("keyspace.name", "JMeterReadThrough");
-		defaultParameters.addArgument("entity.keyNo", "${randomKeyNumber}");
-		return defaultParameters;
-	}
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        getLogger().info("mache setupTest started  \n");
+        //extractParameters(context);
+        getLogger().info("mache setupTest completed. ");
+    }
+    
+    @Override
+    public void teardownTest(JavaSamplerContext context) {
+    }
+    
+    @Override
+    public Arguments getDefaultParameters() {
+        Arguments defaultParameters = new Arguments();
+        defaultParameters.addArgument("cassandra.server.ip.address", "192.168.1.18");
+        defaultParameters.addArgument("keyspace.name", "JMeterReadThrough");
+        defaultParameters.addArgument("entity.keyNo", "${randomKeyNumber}");
+        return defaultParameters;
+    }
 }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
@@ -78,7 +78,7 @@ public abstract class MacheAbstractCassandraKafkaSamplerClient extends AbstractC
                 .addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
 
         cache1 = mache(String.class, CassandraTestEntity.class).backedBy(cassandra()
-                .withContext(connectionContext)
+                .withConnectionContext(connectionContext)
                 .withKeyspace(mapParams.get("keyspace.name")).withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                 .build()).withMessaging(kafkaProvisioner).macheUp();
     }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
@@ -44,14 +44,16 @@ public abstract class MacheAbstractCassandraKafkaSamplerClient extends AbstractC
 
     @Override
     public void teardownTest(JavaSamplerContext context) {
-        if (cache1 != null)
+        if (cache1 != null) {
             cache1.close();
-        if (connectionContext != null)
+        }
+        if (connectionContext != null) {
             try {
                 connectionContext.close();
             } catch (Exception e) {
                 getLogger().error("mache error closing db session", e);
             }
+        }
     }
 
     @Override

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/MacheAbstractCassandraKafkaSamplerClient.java
@@ -1,84 +1,83 @@
 package com.excelian.mache.jmeter.cassandra;
 
-import static com.excelian.mache.builder.MacheBuilder.mache;
-import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
-import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
-
-import java.util.Map;
-
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.excelian.mache.builder.storage.ConnectionContext;
-import org.apache.jmeter.config.Arguments;
-import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
-
-import com.datastax.driver.core.Cluster;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.events.integration.KafkaMqConfig;
 import com.excelian.mache.events.integration.builder.KafkaMessagingProvisioner;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+
+import java.util.Map;
+
+import static com.excelian.mache.builder.MacheBuilder.mache;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
 
 @SuppressWarnings("serial")
 public abstract class MacheAbstractCassandraKafkaSamplerClient extends AbstractCassandraSamplerClient {
 
-	protected Mache<String, CassandraTestEntity> cache1 = null;
-	protected ConnectionContext<Cluster> connectionContext;
+    protected Mache<String, CassandraTestEntity> cache1 = null;
+    protected ConnectionContext<Cluster> connectionContext;
 
-	@Override
-	public void setupTest(JavaSamplerContext context) {
-		Map<String, String> mapParams = extractParameters(context);
-		getLogger().info("mache setupTest started  \n");
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        Map<String, String> mapParams = extractParameters(context);
+        getLogger().info("mache setupTest started  \n");
 
-		try {
-			createCache(mapParams);
-			getLogger().info("mache setupTest completed. ");
+        try {
+            createCache(mapParams);
+            getLogger().info("mache setupTest completed. ");
 
-			getLogger().info("cache connection completed cache is " + cache1);
-		} catch (Exception e) {
-			getLogger().error("mache error building factory", e);
-			throw new RuntimeException(e);
-		}
-	}
+            getLogger().info("cache connection completed cache is " + cache1);
+        } catch (Exception e) {
+            getLogger().error("mache error building factory", e);
+            throw new RuntimeException(e);
+        }
+    }
 
-	@Override
-	public void teardownTest(JavaSamplerContext context) {
-		if (cache1 != null)
-			cache1.close();
-		if(connectionContext!=null)
-			try {
-				connectionContext.close();
-			} catch (Exception e) {
-				getLogger().error("mache error closing db session", e);
-			}
-	}
+    @Override
+    public void teardownTest(JavaSamplerContext context) {
+        if (cache1 != null)
+            cache1.close();
+        if (connectionContext != null)
+            try {
+                connectionContext.close();
+            } catch (Exception e) {
+                getLogger().error("mache error closing db session", e);
+            }
+    }
 
-	@Override
-	public Arguments getDefaultParameters() {
-		Arguments defaultParameters = super.getDefaultParameters();
+    @Override
+    public Arguments getDefaultParameters() {
+        Arguments defaultParameters = super.getDefaultParameters();
 
-		defaultParameters.addArgument("kafka.connection", "192.168.3.4");
-		defaultParameters.addArgument("kafka.topic", "Kafka_JmeterCassandraTest");
-		return defaultParameters;
-	}
+        defaultParameters.addArgument("kafka.connection", "192.168.3.4");
+        defaultParameters.addArgument("kafka.topic", "Kafka_JmeterCassandraTest");
+        return defaultParameters;
+    }
 
-	protected void createCache(Map<String, String> mapParams) throws Exception {
-		final KafkaMessagingProvisioner kafkaProvisioner = KafkaMessagingProvisioner.kafka()
-				.withKafkaMqConfig(KafkaMqConfig.KafkaMqConfigBuilder.builder()
-				.withZkHost(mapParams.get("kafka.connection")).build())
-				.withTopic(mapParams.get("kafka.topic"));
+    protected void createCache(Map<String, String> mapParams) throws Exception {
+        final KafkaMessagingProvisioner kafkaProvisioner = KafkaMessagingProvisioner.kafka()
+                .withKafkaMqConfig(KafkaMqConfig.KafkaMqConfigBuilder.builder()
+                        .withZkHost(mapParams.get("kafka.connection")).build())
+                .withTopic(mapParams.get("kafka.topic"));
 
-		connectionContext = cassandraConnectionContext(Cluster.builder().withClusterName("BluePrint")
-				.withQueryOptions(new QueryOptions().setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM))
-				.withRetryPolicy(DefaultRetryPolicy.INSTANCE)
-				.withLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy()))
-				.addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
+        connectionContext = cassandraConnectionContext(Cluster.builder().withClusterName("BluePrint")
+                .withQueryOptions(new QueryOptions().setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM))
+                .withRetryPolicy(DefaultRetryPolicy.INSTANCE)
+                .withLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy()))
+                .addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
 
-		cache1 = mache(String.class, CassandraTestEntity.class).backedBy(cassandra()
-				.withContext(connectionContext)
-				.withKeyspace(mapParams.get("keyspace.name")).withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
-				.build()).withMessaging(kafkaProvisioner).macheUp();
-	}
+        cache1 = mache(String.class, CassandraTestEntity.class).backedBy(cassandra()
+                .withContext(connectionContext)
+                .withKeyspace(mapParams.get("keyspace.name")).withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
+                .build()).withMessaging(kafkaProvisioner).macheUp();
+    }
 }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromCache.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromCache.java
@@ -1,48 +1,47 @@
 package com.excelian.mache.jmeter.cassandra.knownKeys;
 
-import java.util.Map;
-
+import com.excelian.mache.jmeter.cassandra.MacheAbstractCassandraKafkaSamplerClient;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
 
-import com.excelian.mache.jmeter.cassandra.MacheAbstractCassandraKafkaSamplerClient;
+import java.util.Map;
 
 public class ReadFromCache extends MacheAbstractCassandraKafkaSamplerClient {
-	private static final long serialVersionUID = -8612414345680365704L;
+    private static final long serialVersionUID = -8612414345680365704L;
 
-	@Override
-	public void setupTest(JavaSamplerContext context) {
-		super.setupTest(context);
-	}
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        super.setupTest(context);
+    }
 
-	@Override
-	public void teardownTest(JavaSamplerContext context) {
-		super.teardownTest(context);
-	}
+    @Override
+    public void teardownTest(JavaSamplerContext context) {
+        super.teardownTest(context);
+    }
 
-	@Override
-	public SampleResult runTest(JavaSamplerContext context) {
-		final SampleResult result = new SampleResult();
-		result.sampleStart();
+    @Override
+    public SampleResult runTest(JavaSamplerContext context) {
+        final SampleResult result = new SampleResult();
+        result.sampleStart();
 
-		try {
-			readFromCache(extractParameters(context));
-			result.sampleEnd();
-			result.setSuccessful(true);
-		} catch (Exception e) {
-			result.sampleEnd();
-			result.setSuccessful(false);
-			getLogger().error("Error running test", e);
-			result.setResponseMessage(e.toString());
-		}
+        try {
+            readFromCache(extractParameters(context));
+            result.sampleEnd();
+            result.setSuccessful(true);
+        } catch (Exception e) {
+            result.sampleEnd();
+            result.setSuccessful(false);
+            getLogger().error("Error running test", e);
+            result.setResponseMessage(e.toString());
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	protected void readFromCache(final Map<String, String> params) throws Exception {
-		final String docNumber = params.get("entity.keyNo");
-		final String key = "document_" + docNumber;
-		//getLogger().info("Loading " + key + " cache is " + cache1);
-		cache1.get(key);
-	}
+    protected void readFromCache(final Map<String, String> params) throws Exception {
+        final String docNumber = params.get("entity.keyNo");
+        final String key = "document_" + docNumber;
+        //getLogger().info("Loading " + key + " cache is " + cache1);
+        cache1.get(key);
+    }
 }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromCacheUntilItMatchesValue.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromCacheUntilItMatchesValue.java
@@ -5,8 +5,9 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
 import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ReadFromCacheUntilItMatchesValue extends ReadFromCache {
     private static final long serialVersionUID = -8612323545680365704L;

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromDB.java
@@ -31,7 +31,7 @@ public class ReadFromDB extends AbstractCassandraSamplerClient {
                     .addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
 
             db = cassandra()
-                    .withContext(connectionContext)
+                    .withConnectionContext(connectionContext)
                     .withKeyspace(mapParams.get("keyspace.name"))
                     .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
                     .getCacheLoader(String.class, CassandraTestEntity.class);

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/ReadFromDB.java
@@ -1,81 +1,81 @@
 package com.excelian.mache.jmeter.cassandra.knownKeys;
 
-import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
-import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
-
-import java.util.Map;
-
-import com.excelian.mache.builder.storage.ConnectionContext;
-import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
-import org.apache.jmeter.samplers.SampleResult;
 
 import com.datastax.driver.core.Cluster;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.cassandra.CassandraCacheLoader;
 import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.jmeter.cassandra.AbstractCassandraSamplerClient;
 import com.excelian.mache.jmeter.cassandra.CassandraTestEntity;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+
+import java.util.Map;
+
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
 
 public class ReadFromDB extends AbstractCassandraSamplerClient {
-	private static final long serialVersionUID = 251140199032740124L;
-	private CassandraCacheLoader<String, CassandraTestEntity> db;
-	private ConnectionContext<Cluster> connectionContext;
+    private static final long serialVersionUID = 251140199032740124L;
+    private CassandraCacheLoader<String, CassandraTestEntity> db;
+    private ConnectionContext<Cluster> connectionContext;
 
-	@Override
-	public void setupTest(JavaSamplerContext context) {
-		getLogger().info("ReadFromDB.setupTest");
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        getLogger().info("ReadFromDB.setupTest");
 
-		final Map<String, String> mapParams = extractParameters(context);
+        final Map<String, String> mapParams = extractParameters(context);
 
-		try {
-			connectionContext=cassandraConnectionContext(Cluster.builder().withClusterName("BluePrint")
-					.addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
+        try {
+            connectionContext = cassandraConnectionContext(Cluster.builder().withClusterName("BluePrint")
+                    .addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042));
 
-			db = cassandra()
-					.withContext(connectionContext)
-					.withKeyspace(mapParams.get("keyspace.name"))
-					.withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
-					.getCacheLoader(String.class, CassandraTestEntity.class);
+            db = cassandra()
+                    .withContext(connectionContext)
+                    .withKeyspace(mapParams.get("keyspace.name"))
+                    .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
+                    .getCacheLoader(String.class, CassandraTestEntity.class);
 
-			db.create();// ensure we are connected and schema exists
-		} catch (Exception e) {
-			getLogger().error("Error connecting to cassandra", e);
-		}
-	}
+            db.create();// ensure we are connected and schema exists
+        } catch (Exception e) {
+            getLogger().error("Error connecting to cassandra", e);
+        }
+    }
 
-	@Override
-	public void teardownTest(JavaSamplerContext context) {
-		if (db != null) {
-			db.close();
-		}
-		if(connectionContext!=null){
-			try {
-				connectionContext.close();
-			} catch (Exception e) {
-				getLogger().error("Error closing cassandra context", e);
-			}
-		}
-	}
+    @Override
+    public void teardownTest(JavaSamplerContext context) {
+        if (db != null) {
+            db.close();
+        }
+        if (connectionContext != null) {
+            try {
+                connectionContext.close();
+            } catch (Exception e) {
+                getLogger().error("Error closing cassandra context", e);
+            }
+        }
+    }
 
-	@Override
-	public SampleResult runTest(JavaSamplerContext context) {
-		final SampleResult result = new SampleResult();
-		result.sampleStart();
-		try {
-			readDocumentFromDb(extractParameters(context));
-			result.sampleEnd();
-			result.setSuccessful(true);
-		} catch (Exception e) {
-			result.sampleEnd();
-			result.setSuccessful(false);
-			getLogger().error("Error running test", e);
-			result.setResponseMessage(e.toString());
-		}
-		return result;
-	}
+    @Override
+    public SampleResult runTest(JavaSamplerContext context) {
+        final SampleResult result = new SampleResult();
+        result.sampleStart();
+        try {
+            readDocumentFromDb(extractParameters(context));
+            result.sampleEnd();
+            result.setSuccessful(true);
+        } catch (Exception e) {
+            result.sampleEnd();
+            result.setSuccessful(false);
+            getLogger().error("Error running test", e);
+            result.setResponseMessage(e.toString());
+        }
+        return result;
+    }
 
-	private void readDocumentFromDb(final Map<String, String> params) throws Exception {
-		final String docNumber = params.get("entity.keyNo");
-		final String key = "document_" + docNumber;
-		db.load(key);
-	}
+    private void readDocumentFromDb(final Map<String, String> params) throws Exception {
+        final String docNumber = params.get("entity.keyNo");
+        final String key = "document_" + docNumber;
+        db.load(key);
+    }
 }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
@@ -17,84 +17,84 @@ import com.excelian.mache.jmeter.cassandra.AbstractCassandraSamplerClient;
 import com.excelian.mache.jmeter.cassandra.CassandraTestEntity;
 
 public class WriteToDB extends AbstractCassandraSamplerClient {
-	private static final long serialVersionUID = 4662847886347883622L;
-	private AbstractCacheLoader<String, CassandraTestEntity, ?> db;
-	private ConnectionContext<Cluster> connectionContext;
+    private static final long serialVersionUID = 4662847886347883622L;
+    private AbstractCacheLoader<String, CassandraTestEntity, ?> db;
+    private ConnectionContext<Cluster> connectionContext;
 
-	@Override
-	public void setupTest(JavaSamplerContext context) {
-		getLogger().info(getClass().getName() + ".setupTest");
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        getLogger().info(getClass().getName() + ".setupTest");
 
-		final Map<String, String> mapParams = extractParameters(context);
+        final Map<String, String> mapParams = extractParameters(context);
 
-		try {
-			connectionContext = cassandraConnectionContext(
-					Cluster.builder()
-							.addContactPoint(mapParams.get("cassandra.server.ip.address"))
-							.withPort(9042)
-							.withClusterName("BluePrint") );
+        try {
+            connectionContext = cassandraConnectionContext(
+                    Cluster.builder()
+                            .addContactPoint(mapParams.get("cassandra.server.ip.address"))
+                            .withPort(9042)
+                            .withClusterName("BluePrint") );
 
-			db = cassandra()
-					.withContext(connectionContext)
-					.withKeyspace(mapParams.get("keyspace.name"))
-					.withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
-					.getCacheLoader(String.class, CassandraTestEntity.class);
-			db.create();// ensure we are connected and schema exists
-		} catch (Exception e) {
-			getLogger().error("Error connecting to cassandra", e);
-		}
-	}
+            db = cassandra()
+                    .withContext(connectionContext)
+                    .withKeyspace(mapParams.get("keyspace.name"))
+                    .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
+                    .getCacheLoader(String.class, CassandraTestEntity.class);
+            db.create();// ensure we are connected and schema exists
+        } catch (Exception e) {
+            getLogger().error("Error connecting to cassandra", e);
+        }
+    }
 
-	@Override
-	public void teardownTest(JavaSamplerContext context) {
-		if (db != null) {
-			db.close();
-		}
+    @Override
+    public void teardownTest(JavaSamplerContext context) {
+        if (db != null) {
+            db.close();
+        }
 
-		if(connectionContext!=null){
-			try {
-				connectionContext.close();
-			} catch (Exception e) {
-				getLogger().error("Error closing cassandra context", e);
-			}
-		}
-	}
+        if(connectionContext != null) {
+            try {
+                connectionContext.close();
+            } catch (Exception e) {
+                getLogger().error("Error closing cassandra context", e);
+            }
+        }
+    }
 
-	@Override
-	public SampleResult runTest(JavaSamplerContext context) {
-		final SampleResult result = new SampleResult();
-		result.sampleStart();
-		try{
-			writeDocumentToDbWithNewData(extractParameters(context));
-			result.sampleEnd();
-			result.setSuccessful(true);
-		}
-		catch (Exception e) {
-			result.sampleEnd();
-			result.setSuccessful(false);
-			getLogger().error("Error running test", e);
-			result.setResponseMessage(e.toString());
-		}
+    @Override
+    public SampleResult runTest(JavaSamplerContext context) {
+        final SampleResult result = new SampleResult();
+        result.sampleStart();
+        try {
+            writeDocumentToDbWithNewData(extractParameters(context));
+            result.sampleEnd();
+            result.setSuccessful(true);
+        }
+        catch (Exception e) {
+            result.sampleEnd();
+            result.setSuccessful(false);
+            getLogger().error("Error running test", e);
+            result.setResponseMessage(e.toString());
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private void writeDocumentToDbWithNewData(final Map<String, String> params) {
+    private void writeDocumentToDbWithNewData(final Map<String, String> params) {
 
-		final String docNumber = params.get("entity.keyNo");
-		final String entityValue = params.get("entity.value");
-		final String key = "document_" + docNumber;
-		final String value = (entityValue.equals("CURRENTTIME")) ? key + "_" + System.currentTimeMillis() : entityValue;
-		
-		getLogger().info("Writing to db key=" + key);
-		db.put(key, new CassandraTestEntity(key, value));
-	}
+        final String docNumber = params.get("entity.keyNo");
+        final String entityValue = params.get("entity.value");
+        final String key = "document_" + docNumber;
+        final String value = (entityValue.equals("CURRENTTIME")) ? key + "_" + System.currentTimeMillis() : entityValue;
+        
+        getLogger().info("Writing to db key=" + key);
+        db.put(key, new CassandraTestEntity(key, value));
+    }
 
-	@Override
-	public Arguments getDefaultParameters() {
-		Arguments defaultParameters = super.getDefaultParameters();
+    @Override
+    public Arguments getDefaultParameters() {
+        Arguments defaultParameters = super.getDefaultParameters();
 
-		defaultParameters.addArgument("entity.value", "CURRENTTIME");
-		return defaultParameters;
-	}
+        defaultParameters.addArgument("entity.value", "CURRENTTIME");
+        return defaultParameters;
+    }
 }

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
@@ -35,7 +35,7 @@ public class WriteToDB extends AbstractCassandraSamplerClient {
                             .withClusterName("BluePrint") );
 
             db = cassandra()
-                    .withContext(connectionContext)
+                    .withConnectionContext(connectionContext)
                     .withKeyspace(mapParams.get("keyspace.name"))
                     .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
                     .getCacheLoader(String.class, CassandraTestEntity.class);

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/cassandra/knownKeys/WriteToDB.java
@@ -1,9 +1,11 @@
 package com.excelian.mache.jmeter.cassandra.knownKeys;
 
 import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
 
 import java.util.Map;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
@@ -17,6 +19,7 @@ import com.excelian.mache.jmeter.cassandra.CassandraTestEntity;
 public class WriteToDB extends AbstractCassandraSamplerClient {
 	private static final long serialVersionUID = 4662847886347883622L;
 	private AbstractCacheLoader<String, CassandraTestEntity, ?> db;
+	private ConnectionContext<Cluster> connectionContext;
 
 	@Override
 	public void setupTest(JavaSamplerContext context) {
@@ -25,9 +28,14 @@ public class WriteToDB extends AbstractCassandraSamplerClient {
 		final Map<String, String> mapParams = extractParameters(context);
 
 		try {
+			connectionContext = cassandraConnectionContext(
+					Cluster.builder()
+							.addContactPoint(mapParams.get("cassandra.server.ip.address"))
+							.withPort(9042)
+							.withClusterName("BluePrint") );
+
 			db = cassandra()
-					.withCluster(Cluster.builder().withClusterName("BluePrint")
-							.addContactPoint(mapParams.get("cassandra.server.ip.address")).withPort(9042).build())
+					.withContext(connectionContext)
 					.withKeyspace(mapParams.get("keyspace.name"))
 					.withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED).build()
 					.getCacheLoader(String.class, CassandraTestEntity.class);
@@ -41,6 +49,14 @@ public class WriteToDB extends AbstractCassandraSamplerClient {
 	public void teardownTest(JavaSamplerContext context) {
 		if (db != null) {
 			db.close();
+		}
+
+		if(connectionContext!=null){
+			try {
+				connectionContext.close();
+			} catch (Exception e) {
+				getLogger().error("Error closing cassandra context", e);
+			}
 		}
 	}
 

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/MacheAbstractCouchKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/MacheAbstractCouchKafkaSamplerClient.java
@@ -74,7 +74,7 @@ public abstract class MacheAbstractCouchKafkaSamplerClient extends AbstractCouch
         final String keySpace = mapParams.get("keyspace.name");
         final String couchServer = mapParams.get("couch.server.ip.address");
 
-        connectionContext = couchbaseConnectionContext(couchServer);
+        connectionContext = couchbaseConnectionContext(couchServer, DefaultCouchbaseEnvironment.create());
 
         final Mache<String, CouchTestEntity> mache = mache(String.class, CouchTestEntity.class)
             .backedBy(couchbase()

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/MacheAbstractCouchKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/MacheAbstractCouchKafkaSamplerClient.java
@@ -80,7 +80,6 @@ public abstract class MacheAbstractCouchKafkaSamplerClient extends AbstractCouch
             .backedBy(couchbase()
                     .withContext(connectionContext)
                     .withBucketSettings(builder().name(keySpace).quota(150).build())
-                    .withDefaultAdminDetails()
                     .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                     .build())
             .withMessaging(kafkaProvisioner)

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/ReadFromDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/ReadFromDB.java
@@ -40,7 +40,6 @@ public class ReadFromDB extends AbstractCouchSamplerClient {
             final Mache<String, CouchTestEntity> mache = mache(String.class, CouchTestEntity.class)
                 .backedBy(couchbase().withContext(connectionContext)
                         .withBucketSettings(builder().name(keySpace).quota(150).build())
-                        .withDefaultAdminDetails()
                         .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                         .build())
                 .withNoMessaging()

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/ReadFromDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/ReadFromDB.java
@@ -35,7 +35,7 @@ public class ReadFromDB extends AbstractCouchSamplerClient {
             final String keySpace = mapParams.get("keyspace.name");
             final String couchServer = mapParams.get("couch.server.ip.address");
 
-            connectionContext = couchbaseConnectionContext(couchServer);
+            connectionContext = couchbaseConnectionContext(couchServer, DefaultCouchbaseEnvironment.create());
 
             final Mache<String, CouchTestEntity> mache = mache(String.class, CouchTestEntity.class)
                 .backedBy(couchbase().withContext(connectionContext)

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
@@ -33,7 +33,7 @@ public class WriteToDB extends AbstractCouchSamplerClient {
             final String keySpace = mapParams.get("keyspace.name");
             final String couchServer = mapParams.get("couch.server.ip.address");
 
-            connectionContext = couchbaseConnectionContext(couchServer);
+            connectionContext = couchbaseConnectionContext(couchServer, DefaultCouchbaseEnvironment.create());
 
             db = couchbase().withContext(connectionContext)
                 .withBucketSettings(builder().name(keySpace).quota(150).build())

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
@@ -36,7 +36,6 @@ public class WriteToDB extends AbstractCouchSamplerClient {
 
             db = couchbase().withContext(connectionContext)
                     .withBucketSettings(builder().name(keySpace).quota(150).build())
-                    .withDefaultAdminDetails()
                     .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                     .build().getCacheLoader(String.class, CouchTestEntity.class);
 

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/couch/knownKeys/WriteToDB.java
@@ -1,7 +1,6 @@
 package com.excelian.mache.jmeter.couch.knownKeys;
 
 import com.couchbase.client.java.Cluster;
-import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.AbstractCacheLoader;
@@ -12,11 +11,11 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
 
+import java.util.Map;
+
 import static com.couchbase.client.java.cluster.DefaultBucketSettings.builder;
 import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbase;
 import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbaseConnectionContext;
-
-import java.util.Map;
 
 public class WriteToDB extends AbstractCouchSamplerClient {
     private static final long serialVersionUID = 4662847886347883622L;
@@ -36,10 +35,10 @@ public class WriteToDB extends AbstractCouchSamplerClient {
             connectionContext = couchbaseConnectionContext(couchServer, DefaultCouchbaseEnvironment.create());
 
             db = couchbase().withContext(connectionContext)
-                .withBucketSettings(builder().name(keySpace).quota(150).build())
-                .withDefaultAdminDetails()
-                .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
-                .build().getCacheLoader(String.class, CouchTestEntity.class);
+                    .withBucketSettings(builder().name(keySpace).quota(150).build())
+                    .withDefaultAdminDetails()
+                    .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
+                    .build().getCacheLoader(String.class, CouchTestEntity.class);
 
             db.create();// ensure we are connected and schema exists
 
@@ -54,8 +53,7 @@ public class WriteToDB extends AbstractCouchSamplerClient {
             db.close();
         }
 
-        if(connectionContext!=null)
-        {
+        if (connectionContext != null) {
             try {
                 connectionContext.close();
             } catch (Exception e) {

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/MacheAbstractMongoKafkaSamplerClient.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/MacheAbstractMongoKafkaSamplerClient.java
@@ -72,7 +72,7 @@ public abstract class MacheAbstractMongoKafkaSamplerClient extends AbstractMongo
 
         cache1 = mache(String.class, com.excelian.mache.jmeter.mongo.MongoTestEntity.class)
             .backedBy(mongodb()
-                .withContext(connectionContext)
+                .withConnectionContext(connectionContext)
                 .withDatabase(mapParams.get("keyspace.name"))
                 .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                 .build())

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/knownKeys/ReadFromDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/knownKeys/ReadFromDB.java
@@ -34,7 +34,7 @@ public class ReadFromDB extends AbstractMongoSamplerClient {
 
             final Mache<String, MongoTestEntity> mache = mache(String.class, MongoTestEntity.class)
                 .backedBy(mongodb()
-                    .withContext(connectionContext)
+                    .withConnectionContext(connectionContext)
                     .withDatabase(mapParams.get("keyspace.name"))
                     .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                     .build()).withNoMessaging().macheUp();

--- a/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/knownKeys/WriteToDB.java
+++ b/jmeter/src/main/java/com/excelian/mache/jmeter/mongo/knownKeys/WriteToDB.java
@@ -32,7 +32,7 @@ public class WriteToDB extends AbstractMongoSamplerClient {
             connectionContext = mongoConnectionContext(new ServerAddress(mapParams.get("mongo.server.ip.address"), 27017));
 
             db = mongodb()
-                .withContext(connectionContext)
+                .withConnectionContext(connectionContext)
                 .withDatabase(mapParams.get("keyspace.name"))
                 .withSchemaOptions(SchemaOptions.CREATE_SCHEMA_IF_NEEDED)
                 .build().getCacheLoader(String.class, MongoTestEntity.class);

--- a/mache-activemq/build.gradle
+++ b/mache-activemq/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':mache-core')
   compile project(':mache-observable')
-  compile 'org.apache.activemq:activemq-core:5.7.0'
+  compile 'org.apache.activemq:activemq-all:5.13.0'
   testCompile project(path: ':mache-observable', configuration: 'tests')
   testCompile project(path: ':mache-core', configuration: 'tests')
 }

--- a/mache-cassandra/build.gradle
+++ b/mache-cassandra/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':mache-core')
     compile 'com.datastax.cassandra:cassandra-driver-core:2.1.4'
-    compile 'org.springframework.data:spring-data-cassandra:1.2.0.RELEASE'
+    compile 'org.springframework.data:spring-data-cassandra:1.3.0.RELEASE'
     testCompile project(path: ':mache-core', configuration: 'tests')
 }

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/CassandraCacheLoader.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/CassandraCacheLoader.java
@@ -125,14 +125,6 @@ public class CassandraCacheLoader<K, V> extends AbstractCacheLoader<K, V, Sessio
         return valueType.getSimpleName();
     }
 
-    @Override
-    public Session getDriverSession() {
-        if (session == null) {
-            throw new IllegalStateException("Session has not been created - read/write to cache first");
-        }
-        return session;
-    }
-
     private CassandraOperations ops() {
         return new CassandraTemplate(session);
     }

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/CassandraCacheLoader.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/CassandraCacheLoader.java
@@ -63,7 +63,7 @@ public class CassandraCacheLoader<K, V> extends AbstractCacheLoader<K, V, Sessio
         if (schemaOption.shouldCreateSchema() && session == null) {
             synchronized (this) {
                 if (session == null) {
-                    session = connectionContext.getStorage().connect();
+                    session = connectionContext.getConnection().connect();
                     if (schemaOption.shouldCreateSchema()) {
                         createKeySpace();
                     }
@@ -71,7 +71,7 @@ public class CassandraCacheLoader<K, V> extends AbstractCacheLoader<K, V, Sessio
                 }
             }
         } else {
-            session = connectionContext.getStorage().connect(keySpace);
+            session = connectionContext.getConnection().connect(keySpace);
         }
     }
 
@@ -132,7 +132,7 @@ public class CassandraCacheLoader<K, V> extends AbstractCacheLoader<K, V, Sessio
     @Override
     public String toString() {
         return "CassandraCacheLoader{"
-                + "storageContext=" + connectionContext
+                + "connectionContext=" + connectionContext
                 + ", schemaOption=" + schemaOption
                 + ", replicationClass='" + replicationClass + '\''
                 + ", replicationFactor=" + replicationFactor

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
@@ -41,7 +41,7 @@ public class CassandraProvisioner implements StorageProvisioner {
             Cluster cluster;
 
             @Override
-            public Cluster getStorage() {
+            public Cluster getConnection() {
                 if (cluster == null)
                     synchronized (this) {
                         if (cluster == null) {
@@ -80,7 +80,7 @@ public class CassandraProvisioner implements StorageProvisioner {
      * Forces cluster settings to be provided.
      */
     public interface ClusterBuilder {
-        KeyspaceBuilder withContext(ConnectionContext<Cluster> connectionContext);
+        KeyspaceBuilder withConnectionContext(ConnectionContext<Cluster> connectionContext);
     }
 
     /**

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
@@ -55,8 +55,10 @@ public class CassandraProvisioner implements StorageProvisioner {
             public void close() throws Exception {
                 if (cluster != null)
                     synchronized (this) {
-                        cluster.close();
-                        cluster = null;
+                        if (cluster != null) {
+                            cluster.close();
+                            cluster = null;
+                        }
                     }
             }
         };

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
@@ -28,18 +28,6 @@ public class CassandraProvisioner implements StorageProvisioner {
         this.replicationFactor = replicationFactor;
     }
 
-    @Override
-    public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
-        final MacheFactory macheFactory = new MacheFactory();
-        return macheFactory.create(getCacheLoader(keyType, valueType));
-    }
-    
-    @Override
-    public <K, V> CassandraCacheLoader<K, V> getCacheLoader(Class<K> keyType, Class<V> valueType) {
-    	return new CassandraCacheLoader<>(keyType, valueType, connectionContext,
-                schemaOptions, keySpace, replicationClass, replicationFactor);
-    }
-
     /**
      * @return A builder for a {@link CassandraProvisioner}.
      */
@@ -47,18 +35,17 @@ public class CassandraProvisioner implements StorageProvisioner {
         return storageContext -> keyspace -> new CassandraProvisionerBuilder(storageContext, keyspace);
     }
 
-    public static ConnectionContext<Cluster> cassandraConnectionContext(final Cluster.Builder builder)
-    {
+    public static ConnectionContext<Cluster> cassandraConnectionContext(final Cluster.Builder builder) {
         return new ConnectionContext<Cluster>() {
 
             Cluster cluster;
 
             @Override
             public Cluster getStorage() {
-                if(cluster==null)
+                if (cluster == null)
                     synchronized (this) {
-                        if(cluster==null) {
-                            cluster=builder.build();
+                        if (cluster == null) {
+                            cluster = builder.build();
                         }
                     }
                 return cluster;
@@ -73,6 +60,18 @@ public class CassandraProvisioner implements StorageProvisioner {
                     }
             }
         };
+    }
+
+    @Override
+    public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
+        final MacheFactory macheFactory = new MacheFactory();
+        return macheFactory.create(getCacheLoader(keyType, valueType));
+    }
+
+    @Override
+    public <K, V> CassandraCacheLoader<K, V> getCacheLoader(Class<K> keyType, Class<V> valueType) {
+        return new CassandraCacheLoader<>(keyType, valueType, connectionContext,
+                schemaOptions, keySpace, replicationClass, replicationFactor);
     }
 
     /**

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
@@ -57,7 +57,7 @@ public class CassandraProvisioner implements StorageProvisioner {
             public Cluster getStorage() {
                 if(cluster==null)
                     synchronized (this) {
-                        if(cluster==null){
+                        if(cluster==null) {
                             cluster=builder.build();
                         }
                     }

--- a/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
+++ b/mache-cassandra/src/main/java/com/excelian/mache/cassandra/builder/CassandraProvisioner.java
@@ -1,6 +1,7 @@
 package com.excelian.mache.cassandra.builder;
 
 import com.datastax.driver.core.Cluster;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.builder.storage.StorageProvisioner;
 import com.excelian.mache.cassandra.CassandraCacheLoader;
 import com.excelian.mache.core.Mache;
@@ -12,15 +13,15 @@ import com.excelian.mache.core.SchemaOptions;
  */
 public class CassandraProvisioner implements StorageProvisioner {
 
-    private final Cluster cluster;
+    private final ConnectionContext<Cluster> connectionContext;
     private final SchemaOptions schemaOptions;
     private final String keySpace;
     private final String replicationClass;
     private final int replicationFactor;
 
-    private CassandraProvisioner(Cluster cluster, SchemaOptions schemaOptions, String keySpace,
+    private CassandraProvisioner(ConnectionContext<Cluster> connectionContext, SchemaOptions schemaOptions, String keySpace,
                                  String replicationClass, int replicationFactor) {
-        this.cluster = cluster;
+        this.connectionContext = connectionContext;
         this.schemaOptions = schemaOptions;
         this.keySpace = keySpace;
         this.replicationClass = replicationClass;
@@ -35,7 +36,7 @@ public class CassandraProvisioner implements StorageProvisioner {
     
     @Override
     public <K, V> CassandraCacheLoader<K, V> getCacheLoader(Class<K> keyType, Class<V> valueType) {
-    	return new CassandraCacheLoader<>(keyType, valueType, cluster,
+    	return new CassandraCacheLoader<>(keyType, valueType, connectionContext,
                 schemaOptions, keySpace, replicationClass, replicationFactor);
     }
 
@@ -43,14 +44,42 @@ public class CassandraProvisioner implements StorageProvisioner {
      * @return A builder for a {@link CassandraProvisioner}.
      */
     public static ClusterBuilder cassandra() {
-        return cluster -> keyspace -> new CassandraProvisionerBuilder(cluster, keyspace);
+        return storageContext -> keyspace -> new CassandraProvisionerBuilder(storageContext, keyspace);
+    }
+
+    public static ConnectionContext<Cluster> cassandraConnectionContext(final Cluster.Builder builder)
+    {
+        return new ConnectionContext<Cluster>() {
+
+            Cluster cluster;
+
+            @Override
+            public Cluster getStorage() {
+                if(cluster==null)
+                    synchronized (this) {
+                        if(cluster==null){
+                            cluster=builder.build();
+                        }
+                    }
+                return cluster;
+            }
+
+            @Override
+            public void close() throws Exception {
+                if (cluster != null)
+                    synchronized (this) {
+                        cluster.close();
+                        cluster = null;
+                    }
+            }
+        };
     }
 
     /**
      * Forces cluster settings to be provided.
      */
     public interface ClusterBuilder {
-        KeyspaceBuilder withCluster(Cluster cluster);
+        KeyspaceBuilder withContext(ConnectionContext<Cluster> connectionContext);
     }
 
     /**
@@ -64,14 +93,14 @@ public class CassandraProvisioner implements StorageProvisioner {
      * A builder with defaults for a Cassandra cluster.
      */
     public static class CassandraProvisionerBuilder {
-        private final Cluster cluster;
+        private final ConnectionContext<Cluster> connectionContext;
         private final String keySpace;
         private SchemaOptions schemaOptions = SchemaOptions.USE_EXISTING_SCHEMA;
         private String replicationClass = "SimpleStrategy";
         private int replicationFactor = 1;
 
-        private CassandraProvisionerBuilder(Cluster cluster, String keySpace) {
-            this.cluster = cluster;
+        private CassandraProvisionerBuilder(ConnectionContext<Cluster> connectionContext, String keySpace) {
+            this.connectionContext = connectionContext;
             this.keySpace = keySpace;
         }
 
@@ -91,7 +120,7 @@ public class CassandraProvisioner implements StorageProvisioner {
         }
 
         public CassandraProvisioner build() {
-            return new CassandraProvisioner(cluster, schemaOptions, keySpace, replicationClass, replicationFactor);
+            return new CassandraProvisioner(connectionContext, schemaOptions, keySpace, replicationClass, replicationFactor);
         }
     }
 }

--- a/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
+++ b/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
@@ -38,16 +38,20 @@ public class CassandraCacheLoaderIntegrationTest {
     @BeforeClass
     public static void setUpClass()
     {
-        connectionContext = cassandraConnectionContext(Cluster.builder()
-                .addContactPoint(new NoRunningCassandraDbForTests().getHost())
-                .withPort(9042)
-                .withClusterName("BluePrint"));
+        if(new NoRunningCassandraDbForTests().isSatisfied()==false) {
+            connectionContext = cassandraConnectionContext(Cluster.builder()
+                    .addContactPoint(new NoRunningCassandraDbForTests().getHost())
+                    .withPort(9042)
+                    .withClusterName("BluePrint"));
+        }
     }
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        connectionContext.close();
-        connectionContext=null;
+        if(connectionContext!=null) {
+            connectionContext.close();
+            connectionContext = null;
+        }
     }
 
     @Before

--- a/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
+++ b/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
@@ -70,7 +70,7 @@ public class CassandraCacheLoaderIntegrationTest {
 
         return mache(keyType, valueType)
                 .backedBy(cassandra()
-                        .withContext(connectionContext)
+                        .withConnectionContext(connectionContext)
                         .withKeyspace(keySpace)
                         .withSchemaOptions(schemaOptions)
                         .build())

--- a/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
+++ b/mache-cassandra/src/test/java/com/excelian/mache/cassandra/CassandraCacheLoaderIntegrationTest.java
@@ -2,6 +2,7 @@ package com.excelian.mache.cassandra;
 
 import com.codeaffine.test.ConditionalIgnoreRule;
 import com.datastax.driver.core.Cluster;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.core.SchemaOptions;
 import com.google.common.cache.CacheLoader;
@@ -19,6 +20,7 @@ import java.util.Date;
 
 import static com.excelian.mache.builder.MacheBuilder.mache;
 import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -29,43 +31,47 @@ public class CassandraCacheLoaderIntegrationTest {
     public final ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
 
     protected static String keySpace = "NoSQL_Nearside_Test_" + new Date().toString();
+
+    private static ConnectionContext<Cluster> connectionContext;
     private Mache<String, TestEntity> mache;
-    private Cluster cluster;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        connectionContext = cassandraConnectionContext(Cluster.builder()
+                .addContactPoint(new NoRunningCassandraDbForTests().getHost())
+                .withPort(9042)
+                .withClusterName("BluePrint"));
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        connectionContext.close();
+        connectionContext=null;
+    }
 
     @Before
     public void setUp() throws Exception {
-        cluster = Cluster.builder()
-                .withClusterName("BluePrint")
-                .addContactPoint(new NoRunningCassandraDbForTests().getHost())
-                .withPort(9042)
-                .build();
-
-        mache = getMache(String.class, TestEntity.class, cluster);
+        mache = getMache(String.class, TestEntity.class, connectionContext, SchemaOptions.CREATE_AND_DROP_SCHEMA);
     }
 
     @After
     public void tearDown() throws Exception {
         mache.close();
-        cluster.close();
     }
 
-    private static <K, V> Mache<K, V> getMache(Class<K> keyType, Class<V> valueType, Cluster cluster) throws Exception {
+    private static <K, V> Mache<K, V> getMache(Class<K> keyType, Class<V> valueType
+            , ConnectionContext<Cluster> connectionContext
+                                               ,SchemaOptions schemaOptions   ) throws Exception {
 
         return mache(keyType, valueType)
                 .backedBy(cassandra()
-                        .withCluster(cluster)
+                        .withContext(connectionContext)
                         .withKeyspace(keySpace)
-                        .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
+                        .withSchemaOptions(schemaOptions)
                         .build())
                 .withNoMessaging()
                 .macheUp();
-    }
-
-    @Test
-    public void testCanGetDriverSession() throws Exception {
-        mache.put("test-2", new TestEntity("test-2"));
-        mache.get("test-2");
-        assertNotNull(mache.getCacheLoader().getDriverSession());
     }
 
     @Test
@@ -105,17 +111,18 @@ public class CassandraCacheLoaderIntegrationTest {
         mache.put("test-2", new TestEntity("test-2"));
         mache.put("test-3", new TestEntity("test-3"));
         // replace the cache
-        mache = getMache(String.class, TestEntity.class, cluster);
-
-        TestEntity test = mache.get("test-2");
-        assertEquals("test-2", test.pkString);
+        try(Mache<String, TestEntity> anothermache = getMache(String.class, TestEntity.class, connectionContext, SchemaOptions.CREATE_SCHEMA_IF_NEEDED))
+        {
+            TestEntity test = anothermache.get("test-2");
+            assertEquals("test-2", test.pkString);
+        }
     }
 
     @Test
     public void testPutComposite() throws Exception {
 
         try(Mache<CompositeKey, TestEntityWithCompositeKey> compCache =
-                getMache(CompositeKey.class, TestEntityWithCompositeKey.class, cluster))
+                getMache(CompositeKey.class, TestEntityWithCompositeKey.class, connectionContext, SchemaOptions.CREATE_AND_DROP_SCHEMA))
         {
 
             TestEntityWithCompositeKey value = new TestEntityWithCompositeKey("neil", "mac", "explorer");

--- a/mache-core/src/main/java/com/excelian/mache/builder/storage/ConnectionContext.java
+++ b/mache-core/src/main/java/com/excelian/mache/builder/storage/ConnectionContext.java
@@ -1,5 +1,5 @@
 package com.excelian.mache.builder.storage;
 
 public interface ConnectionContext<C> extends AutoCloseable {
-    C getStorage();
+    C getConnection();
 }

--- a/mache-core/src/main/java/com/excelian/mache/builder/storage/ConnectionContext.java
+++ b/mache-core/src/main/java/com/excelian/mache/builder/storage/ConnectionContext.java
@@ -1,0 +1,5 @@
+package com.excelian.mache.builder.storage;
+
+public interface ConnectionContext<C> extends AutoCloseable {
+    C getStorage();
+}

--- a/mache-core/src/main/java/com/excelian/mache/core/MacheLoader.java
+++ b/mache-core/src/main/java/com/excelian/mache/core/MacheLoader.java
@@ -48,11 +48,4 @@ public interface MacheLoader<K, V, D> extends AutoCloseable {
      * @return A simple name to describe implementers of this class
      */
     String getName();
-
-    /*
-     * @return a session to the underlying driver
-     */
-    //todo: this method is only called in test code - can we remove it and the
-    // generic declaration at the top of this class too?
-    D getDriverSession();
 }

--- a/mache-core/src/test/java/com/excelian/mache/core/InMemoryCacheLoader.java
+++ b/mache-core/src/test/java/com/excelian/mache/core/InMemoryCacheLoader.java
@@ -38,11 +38,6 @@ public class InMemoryCacheLoader<K, V, D> extends AbstractCacheLoader<K, V, Obje
     }
 
     @Override
-    public String getDriverSession() {
-        throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
     public V load(K key) throws Exception {
         V result = store.get(key);
 

--- a/mache-core/src/test/java/com/excelian/mache/core/TestEnvironmentPortCheckIgnoreCondition.java
+++ b/mache-core/src/test/java/com/excelian/mache/core/TestEnvironmentPortCheckIgnoreCondition.java
@@ -19,7 +19,7 @@ public abstract class TestEnvironmentPortCheckIgnoreCondition implements Conditi
             host = "localhost";
             hostPresent = true;
         } else {
-            host = "not-set";
+            host = "not-set-as-no-host-running";
             hostPresent = false;
         }
     }

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
@@ -63,7 +63,7 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
 
         if(connectionContext==null)
         {
-            throw new NullPointerException("Cluster cannot be null");
+            throw new NullPointerException("ConnectionContext cannot be null");
         }
     }
 

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
@@ -2,18 +2,14 @@ package com.excelian.mache.couchbase;
 
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
-import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.cluster.BucketSettings;
 import com.couchbase.client.java.cluster.ClusterManager;
-import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.AbstractCacheLoader;
 import com.excelian.mache.core.SchemaOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
-
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -70,7 +66,7 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
         synchronized (this) {
             if (manager == null) {
                 LOG.info("Attempting to connect to authenticate to Couchbase cluster as {}", adminUser);
-                manager = connectionContext.getStorage().clusterManager(adminUser, adminPassword);
+                manager = connectionContext.getConnection().clusterManager(adminUser, adminPassword);
 
                 dropBucketIfRequired();
                 bucket = createBucketIfRequired();
@@ -134,7 +130,7 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
             LOG.info("Creating bucket {}", bucketSettings.name());
             manager.insertBucket(bucketSettings);
         }
-        return connectionContext.getStorage().openBucket(bucketSettings.name());
+        return connectionContext.getConnection().openBucket(bucketSettings.name());
     }
 
     @Override

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
@@ -35,8 +35,6 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
     private ClusterManager manager;
     private CouchbaseTemplate template;
     private BucketSettings bucketSettings;
-
-    private List<String> nodes;
     private String adminUser;
     private String adminPassword;
     private SchemaOptions schemaOptions;
@@ -146,7 +144,6 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
                 + ", manager=" + manager
                 + ", template=" + template
                 + ", bucketSettings=" + bucketSettings
-                + ", nodes=" + nodes
                 + ", adminUser='" + adminUser + '\''
                 + ", adminPassword='" + adminPassword + '\''
                 + ", schemaOptions=" + schemaOptions

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/CouchbaseCacheLoader.java
@@ -120,11 +120,6 @@ public class CouchbaseCacheLoader<K, V> extends AbstractCacheLoader<K, V, Cluste
     }
 
     @Override
-    public Cluster getDriverSession() {
-        return connectionContext.getStorage();
-    }
-
-    @Override
     public String getName() {
         return getClass().getSimpleName();
     }

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
@@ -55,8 +55,10 @@ public class CouchbaseProvisioner implements StorageProvisioner {
             public void close() throws Exception {
                 if (cluster != null) {
                     synchronized (this) {
-                        cluster.disconnect();
-                        cluster = null;
+                        if (cluster != null) {
+                            cluster.disconnect();
+                            cluster = null;
+                        }
                     }
                 }
             }
@@ -156,5 +158,4 @@ public class CouchbaseProvisioner implements StorageProvisioner {
             return new CouchbaseProvisioner(connectionContext, bucketSettings, adminUser, adminPassword, schemaOptions);
         }
     }
-
 }

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.couchbase.client.core.env.DefaultCoreEnvironment;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.cluster.BucketSettings;
@@ -50,7 +51,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
     	return new CouchbaseCacheLoader<>(keyType, valueType, bucketSettings, connectionContext, adminUser, adminPassword, schemaOptions);
     }
 
-    public static ConnectionContext<Cluster> couchbaseConnectionContext(String contactPoint)
+    public static ConnectionContext<Cluster> couchbaseConnectionContext(String contactPoint, DefaultCouchbaseEnvironment builder)
     {
         return new ConnectionContext<Cluster>() {
 
@@ -61,8 +62,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
                 if(cluster==null) {
                     synchronized (this) {
                         if (cluster == null) {
-                            DefaultCouchbaseEnvironment couchbaseEnvironment = DefaultCouchbaseEnvironment.create();
-                            cluster = CouchbaseCluster.create(couchbaseEnvironment, contactPoint);
+                            cluster = CouchbaseCluster.create(builder, contactPoint);
                         }
                     }
                 }
@@ -73,6 +73,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
             public void close() throws Exception {
                 if(cluster!=null) {
                     synchronized (this) {
+
                         cluster.disconnect();
                         cluster = null;
                     }

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
@@ -1,15 +1,8 @@
 package com.excelian.mache.couchbase.builder;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import com.couchbase.client.core.env.DefaultCoreEnvironment;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.cluster.BucketSettings;
-import com.couchbase.client.java.env.CouchbaseEnvironment;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.builder.storage.StorageProvisioner;
@@ -41,25 +34,14 @@ public class CouchbaseProvisioner implements StorageProvisioner {
         this.schemaOptions = schemaOptions;
     }
 
-    @Override
-    public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
-        return new MacheFactory().create(getCacheLoader(keyType, valueType));
-    }
-    
-    @Override
-    public <K, V> AbstractCacheLoader<K, V, ?> getCacheLoader(Class<K> keyType, Class<V> valueType) {
-    	return new CouchbaseCacheLoader<>(keyType, valueType, bucketSettings, connectionContext, adminUser, adminPassword, schemaOptions);
-    }
-
-    public static ConnectionContext<Cluster> couchbaseConnectionContext(String contactPoint, DefaultCouchbaseEnvironment builder)
-    {
+    public static ConnectionContext<Cluster> couchbaseConnectionContext(String contactPoint, DefaultCouchbaseEnvironment builder) {
         return new ConnectionContext<Cluster>() {
 
             Cluster cluster;
 
             @Override
             public Cluster getStorage() {
-                if(cluster==null) {
+                if (cluster == null) {
                     synchronized (this) {
                         if (cluster == null) {
                             cluster = CouchbaseCluster.create(builder, contactPoint);
@@ -71,7 +53,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
 
             @Override
             public void close() throws Exception {
-                if(cluster!=null) {
+                if (cluster != null) {
                     synchronized (this) {
                         cluster.disconnect();
                         cluster = null;
@@ -88,6 +70,16 @@ public class CouchbaseProvisioner implements StorageProvisioner {
         return new CouchbaseProvisionerBuilder();
     }
 
+    @Override
+    public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
+        return new MacheFactory().create(getCacheLoader(keyType, valueType));
+    }
+
+    @Override
+    public <K, V> AbstractCacheLoader<K, V, ?> getCacheLoader(Class<K> keyType, Class<V> valueType) {
+        return new CouchbaseCacheLoader<>(keyType, valueType, bucketSettings, connectionContext, adminUser, adminPassword, schemaOptions);
+    }
+
     /**
      * Forces bucket settings to be provided.
      */
@@ -101,19 +93,20 @@ public class CouchbaseProvisioner implements StorageProvisioner {
 
     public interface AdminSettings {
         SchemaOptionsSettings withAdminDetails(String adminUser, String adminPassword);
+
         SchemaOptionsSettings withDefaultAdminDetails();
     }
 
     public interface SchemaOptionsSettings {
         CouchbaseProvisionerBuilder withSchemaOptions(SchemaOptions schemaOptions);
+
         CouchbaseProvisionerBuilder withDefaultSchemaOptions();
     }
 
     /**
      * A builder with defaults for a Couchbase cluster.
      */
-    public static class CouchbaseProvisionerBuilder implements ClusterBuilder,BucketBuilder,AdminSettings,SchemaOptionsSettings
-    {
+    public static class CouchbaseProvisionerBuilder implements ClusterBuilder, BucketBuilder, AdminSettings, SchemaOptionsSettings {
         private ConnectionContext<Cluster> connectionContext;
         private BucketSettings bucketSettings;
         private String adminUser = "Administrator";
@@ -121,7 +114,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
         private SchemaOptions schemaOptions = SchemaOptions.USE_EXISTING_SCHEMA;
 
         public BucketBuilder withContext(ConnectionContext<Cluster> connectionContext) {
-            if(connectionContext==null) {
+            if (connectionContext == null) {
                 throw new NullPointerException("Cannot build without a connectionContext defined");
             }
 
@@ -155,7 +148,7 @@ public class CouchbaseProvisioner implements StorageProvisioner {
 
         @Override
         public AdminSettings withBucketSettings(BucketSettings bucketSettings) {
-            this.bucketSettings=bucketSettings;
+            this.bucketSettings = bucketSettings;
             return this;
         }
 

--- a/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
+++ b/mache-couchbase/src/main/java/com/excelian/mache/couchbase/builder/CouchbaseProvisioner.java
@@ -73,7 +73,6 @@ public class CouchbaseProvisioner implements StorageProvisioner {
             public void close() throws Exception {
                 if(cluster!=null) {
                     synchronized (this) {
-
                         cluster.disconnect();
                         cluster = null;
                     }

--- a/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderIntegrationTest.java
+++ b/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderIntegrationTest.java
@@ -42,7 +42,7 @@ public class CouchbaseCacheLoaderIntegrationTest {
     @Before
     public void setup() throws Exception {
 
-        connectionContext = couchbaseConnectionContext(COUCHBASE_HOST);
+        connectionContext = couchbaseConnectionContext(COUCHBASE_HOST, couchbaseEnvironment);
 
         cache = mache(String.class, TestEntity.class)
                 .backedBy(couchbase()

--- a/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderIntegrationTest.java
+++ b/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderIntegrationTest.java
@@ -82,18 +82,6 @@ public class CouchbaseCacheLoaderIntegrationTest {
         assertEquals(0.93, cache.get("test3").value, DELTA);
     }
 
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void canGetDriver() {
-        CouchbaseCacheLoader<String, Object> loader = (CouchbaseCacheLoader) cache.getCacheLoader();
-        loader.create();
-        Cluster cluster = loader.getDriverSession();
-        assertNotNull(cluster);
-        loader.close();
-        assertNull(loader.getDriverSession());
-    }
-
     @Document
     public static class TestEntity {
         @Id

--- a/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderMockedTest.java
+++ b/mache-couchbase/src/test/java/com/excelian/mache/couchbase/CouchbaseCacheLoaderMockedTest.java
@@ -28,18 +28,17 @@ import static org.mockito.Mockito.*;
 @RunWith(PowerMockRunner.class)
 public class CouchbaseCacheLoaderMockedTest {
 
+    private static final DefaultCouchbaseEnvironment couchbaseEnvironment = DefaultCouchbaseEnvironment.create();
     CouchbaseCacheLoader loader;
     CouchbaseCluster mockedCluster;
     ClusterManager mockedManager;
-
-    private static final DefaultCouchbaseEnvironment couchbaseEnvironment = DefaultCouchbaseEnvironment.create();
 
     @Before
     public void mockCouchbaseCluster() {
         PowerMockito.mockStatic(CouchbaseCluster.class);
         mockedCluster = mock(CouchbaseCluster.class);
 
-        when(CouchbaseCluster.create(any(CouchbaseEnvironment.class),  anyString()))
+        when(CouchbaseCluster.create(any(CouchbaseEnvironment.class), anyString()))
                 .thenReturn(mockedCluster);
 
         mockedManager = mock(ClusterManager.class);
@@ -48,16 +47,15 @@ public class CouchbaseCacheLoaderMockedTest {
     }
 
     @After
-    public void tearDown()
-    {
-        if(loader!=null){
+    public void tearDown() {
+        if (loader != null) {
             loader.close();
         }
     }
 
     @Test
     public void shouldCreateConnection() throws Exception {
-        try(ConnectionContext connectionContext=couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
+        try (ConnectionContext connectionContext = couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
             givenCacheLoaderWith(connectionContext, SchemaOptions.USE_EXISTING_SCHEMA);
             loader.create();
             thenClusterManagerAndBucketCreated(mockedCluster);
@@ -66,7 +64,7 @@ public class CouchbaseCacheLoaderMockedTest {
 
     @Test
     public void shouldCreateBucket() throws Exception {
-        try(ConnectionContext connectionContext=couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
+        try (ConnectionContext connectionContext = couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
             givenCacheLoaderWith(connectionContext, SchemaOptions.CREATE_SCHEMA_IF_NEEDED);
 
             when(mockedManager.hasBucket(anyString())).thenReturn(false);
@@ -81,7 +79,7 @@ public class CouchbaseCacheLoaderMockedTest {
 
     @Test
     public void shouldDropAndCreateBucket() throws Exception {
-        try(ConnectionContext connectionContext=couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
+        try (ConnectionContext connectionContext = couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
             givenCacheLoaderWith(connectionContext, SchemaOptions.CREATE_AND_DROP_SCHEMA);
 
             when(mockedManager.hasBucket(anyString())).thenAnswer(getAlternatingBooleanAnswer());
@@ -97,7 +95,7 @@ public class CouchbaseCacheLoaderMockedTest {
 
     @Test
     public void shouldCloseCluster() throws Exception {
-        try(ConnectionContext connectionContext=couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
+        try (ConnectionContext connectionContext = couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
             givenCacheLoaderWith(connectionContext, SchemaOptions.USE_EXISTING_SCHEMA);
             loader.create();
             loader.close();
@@ -107,7 +105,7 @@ public class CouchbaseCacheLoaderMockedTest {
 
     @Test
     public void shouldCloseClusterAndDropSchema() throws Exception {
-        try(ConnectionContext connectionContext=couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
+        try (ConnectionContext connectionContext = couchbaseConnectionContext("localhost", couchbaseEnvironment)) {
             givenCacheLoaderWith(connectionContext, SchemaOptions.CREATE_AND_DROP_SCHEMA);
             loader.create();
             when(mockedManager.hasBucket(anyString())).thenReturn(true);
@@ -136,7 +134,7 @@ public class CouchbaseCacheLoaderMockedTest {
 
     private void givenCacheLoaderWith(ConnectionContext<Cluster> connectionContext, SchemaOptions schemaOptions) {
         BucketSettings bucket = DefaultBucketSettings.builder().name("test").build();
-        loader = new CouchbaseCacheLoader<>(String.class, Object.class, bucket,connectionContext, "Admin", "Pass", schemaOptions);
+        loader = new CouchbaseCacheLoader<>(String.class, Object.class, bucket, connectionContext, "Admin", "Pass", schemaOptions);
     }
 
     private Answer<Boolean> getAlternatingBooleanAnswer() {

--- a/mache-example/build.gradle
+++ b/mache-example/build.gradle
@@ -6,12 +6,8 @@ repositories {
 
 dependencies {
     compile project(':mache-core')
-    compile project(':mache-activemq')
-    compile project(':mache-rabbit')
     compile project(':mache-mongo')
     compile project(':mache-cassandra')
-    compile project(':mache-observable')
-    compile project(':mache-core')
     compile project(':mache-couchbase')
 }
 
@@ -28,11 +24,19 @@ test {
 }
 
 task getClient(dependsOn: 'classes', type: JavaExec) {
+    if(project.hasProperty('arg')){
+        args(arg.split(','))
+    }
+
     main = 'com.excelian.mache.examples.GettingCacheClient'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 task putClient(dependsOn: 'classes', type: JavaExec) {
+    if(project.hasProperty('arg')){
+        args(arg.split(','))
+    }
+
     main = 'com.excelian.mache.examples.PuttingCacheClient'
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/Args.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/Args.java
@@ -6,9 +6,11 @@ package com.excelian.mache.examples;
 public class Args {
     final int count;
     final CacheType cacheType;
+    final String host;
 
-    public Args(int count, CacheType cacheType) {
+    public Args(int count, CacheType cacheType, String host) {
         this.count = count;
         this.cacheType = cacheType;
+        this.host = host;
     }
 }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/Example.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/Example.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 
 /**
@@ -7,11 +8,28 @@ import com.excelian.mache.core.Mache;
  *
  * @param <T> The Spring Data Annotated object type.
  */
-public interface Example<T> {
+public interface Example<T,S, M extends Example.KeyedMessge>   {
+
+    /**
+     * Provides connection context for subsequent Mache clients to utilise
+     *
+     * @return The connection context.
+     */
+    public ConnectionContext<S> createConnectionContext();
+
     /**
      * Provides a {@link Mache} type for an example client.
      *
      * @return The example mache client.
      */
-    Mache<String, T> exampleCache() throws Exception;
+    Mache<String, T> exampleCache(ConnectionContext<S> connectionContext) throws Exception;
+
+    M createEntity(String primaryKey, String msg);
+
+
+    public interface KeyedMessge{
+        public String getPrimaryKey();
+    }
 }
+
+

--- a/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
@@ -24,13 +24,13 @@ public class GettingCacheClient {
         final Example example;
         switch (args.cacheType) {
             case Cassandra:
-                example = new CassandraExample();
+                example = new CassandraExample("192.168.2.9");
                 break;
             case Mongo:
-                example = new MongoExample();
+                example = new MongoExample("10.28.1.140");
                 break;
             case Couchbase:
-                example = new CouchbaseExample();
+                example = new CouchbaseExample("10.28.1.140");
                 break;
             default:
                 throw new RuntimeException("Invalid cache type: [" + args.cacheType + "].  Valid values are:"

--- a/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.examples.cassandra.CassandraExample;
 import com.excelian.mache.examples.couchbase.CouchbaseExample;
@@ -38,14 +39,17 @@ public class GettingCacheClient {
         doExample(count, example);
     }
 
-    private static <T> void doExample(int count, Example<T> example) throws Exception {
-        final Mache<String, T> cache = example.exampleCache();
-        LOG.info("Getting...");
-        for (int i = 0; i < count; i++) {
-            final T hello = cache.get("msg_" + i);
-            LOG.info("hello = " + hello);
+    private static <T,C, M extends Example.KeyedMessge> void doExample(int count, Example<T,C, M> example) throws Exception {
+
+        try(ConnectionContext<C> context = example.createConnectionContext()) {
+            try(final Mache<String, T> cache = example.exampleCache(context)) {
+                LOG.info("Getting...");
+                for (int i = 0; i < count; i++) {
+                    final T hello = cache.get("msg_" + i);
+                    LOG.info("hello = " + hello);
+                }
+            }
         }
-        cache.close();
     }
 
     private static Args parseArgs(String[] args) {

--- a/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/GettingCacheClient.java
@@ -21,16 +21,17 @@ public class GettingCacheClient {
     public static void main(String... commandLine) throws Exception {
         final Args args = parseArgs(commandLine);
         final int count = args.count;
+        final String hostAddress = args.host;
         final Example example;
         switch (args.cacheType) {
             case Cassandra:
-                example = new CassandraExample("192.168.2.9");
+                example = new CassandraExample(hostAddress);
                 break;
             case Mongo:
-                example = new MongoExample("10.28.1.140");
+                example = new MongoExample(hostAddress);
                 break;
             case Couchbase:
-                example = new CouchbaseExample("10.28.1.140");
+                example = new CouchbaseExample(hostAddress);
                 break;
             default:
                 throw new RuntimeException("Invalid cache type: [" + args.cacheType + "].  Valid values are:"
@@ -53,10 +54,12 @@ public class GettingCacheClient {
     }
 
     private static Args parseArgs(String[] args) {
-        if (args.length == 2) {
-            final CacheType cacheType = CacheType.valueOf(args[1]);
+        if (args.length == 3) {
             final int count = Integer.parseInt(args[0]);
-            return new Args(count, cacheType);
+            final CacheType cacheType = CacheType.valueOf(args[1]);
+            final String hostAddress = args[2];
+
+            return new Args(count, cacheType, hostAddress);
         } else {
             throw new RuntimeException("Usage : GettingCacheClient <get count> " + Arrays.toString(CacheType.values()));
         }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
@@ -23,17 +23,18 @@ public class PuttingCacheClient {
     public static void main(String... commandLine) throws Exception {
         final Args args = parseArgs(commandLine);
         final int count = args.count;
+        final String hostAddress = args.host;
         Example example;
 
         switch (args.cacheType) {
             case Cassandra:
-                example = new CassandraExample("192.168.2.9");
+                example = new CassandraExample(hostAddress);
                 break;
             case Mongo:
-                example =  new MongoExample("10.28.1.140");
+                example =  new MongoExample(hostAddress);
                 break;
             case Couchbase:
-                example = new CouchbaseExample("10.28.1.140");
+                example = new CouchbaseExample(hostAddress);
                 break;
 
             default:
@@ -60,10 +61,12 @@ public class PuttingCacheClient {
 
 
     private static Args parseArgs(String[] args) {
-        if (args.length == 2) {
-            final CacheType cacheType = CacheType.valueOf(args[1]);
+        if (args.length == 3) {
             final int count = Integer.parseInt(args[0]);
-            return new Args(count, cacheType);
+            final CacheType cacheType = CacheType.valueOf(args[1]);
+            final String ipAddress = args[2];
+
+            return new Args(count, cacheType, ipAddress);
         } else {
             throw new RuntimeException("Usage : PuttingCacheClient <put count> " + Arrays.toString(CacheType.values()));
         }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.examples.cassandra.CassandraAnnotatedMessage;
 import com.excelian.mache.examples.cassandra.CassandraExample;
@@ -22,45 +23,41 @@ public class PuttingCacheClient {
     public static void main(String... commandLine) throws Exception {
         final Args args = parseArgs(commandLine);
         final int count = args.count;
+        Example example;
+
         switch (args.cacheType) {
             case Cassandra:
-                populateWithCassandraMsgs(count, new CassandraExample().exampleCache());
+                example = new CassandraExample();
                 break;
             case Mongo:
-                populateWithMongoMsgs(count, new MongoExample().exampleCache());
+                example =  new MongoExample();
                 break;
             case Couchbase:
-                populateWithCouchbaseMsgs(count, new CouchbaseExample().exampleCache());
+                example = new CouchbaseExample();
                 break;
+
             default:
                 throw new RuntimeException("Invalid cache type: [" + args.cacheType + "].  Valid values are:"
                         + Arrays.toString(CacheType.values()));
         }
+
+        populateWithMsgs(count, example);
     }
 
-    private static void populateWithMongoMsgs(int count, Mache<String, MongoAnnotatedMessage> cache) {
-        LOG.info("Putting...");
-        for (int i = 0; i < count; i++) {
-            final MongoAnnotatedMessage v = new MongoAnnotatedMessage("msg_" + i, "Hello World - " + i);
-            cache.put(v.getPrimaryKey(), v);
+    private static void populateWithMsgs(int count, Example example) throws Exception {
+
+        try(ConnectionContext context =  example.createConnectionContext()) {
+            try(Mache mache = example.exampleCache(context)) {
+                LOG.info("Putting...");
+                for (int i = 0; i < count; i++) {
+                    Example.KeyedMessge v = example.createEntity("msg_" + i, "Hello World - " + i);
+
+                    mache.put(v.getPrimaryKey(), v);
+                }
+            }
         }
     }
 
-    private static void populateWithCassandraMsgs(int count, Mache<String, CassandraAnnotatedMessage> cache) {
-        LOG.info("Putting...");
-        for (int i = 0; i < count; i++) {
-            final CassandraAnnotatedMessage v = new CassandraAnnotatedMessage("msg_" + i, "Hello World - " + i);
-            cache.put(v.getPrimaryKey(), v);
-        }
-    }
-
-    private static void populateWithCouchbaseMsgs(int count, Mache<String, CouchbaseAnnotatedMessage> cache) {
-        LOG.info("Putting...");
-        for (int i = 0; i < count; i++) {
-            final CouchbaseAnnotatedMessage v = new CouchbaseAnnotatedMessage("msg_" + i, "Hello World - " + i);
-            cache.put(v.getPrimaryKey(), v);
-        }
-    }
 
     private static Args parseArgs(String[] args) {
         if (args.length == 2) {

--- a/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/PuttingCacheClient.java
@@ -27,13 +27,13 @@ public class PuttingCacheClient {
 
         switch (args.cacheType) {
             case Cassandra:
-                example = new CassandraExample();
+                example = new CassandraExample("192.168.2.9");
                 break;
             case Mongo:
-                example =  new MongoExample();
+                example =  new MongoExample("10.28.1.140");
                 break;
             case Couchbase:
-                example = new CouchbaseExample();
+                example = new CouchbaseExample("10.28.1.140");
                 break;
 
             default:

--- a/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraAnnotatedMessage.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraAnnotatedMessage.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples.cassandra;
 
+import com.excelian.mache.examples.Example;
 import org.springframework.data.cassandra.mapping.PrimaryKey;
 import org.springframework.data.cassandra.mapping.Table;
 
@@ -7,7 +8,7 @@ import org.springframework.data.cassandra.mapping.Table;
  * Example Spring Data Cassandra Annotated Object.
  */
 @Table
-public class CassandraAnnotatedMessage {
+public class CassandraAnnotatedMessage implements Example.KeyedMessge {
 
     private final String msg;
 

--- a/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
@@ -40,7 +40,7 @@ public class CassandraExample implements Example<CassandraAnnotatedMessage, Clus
 
         return mache(String.class, CassandraAnnotatedMessage.class)
                 .backedBy(cassandra()
-                        .withContext(connectionContext)
+                        .withConnectionContext(connectionContext)
                         .withKeyspace(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA).build())
                 .withNoMessaging()

--- a/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
@@ -1,6 +1,7 @@
 package com.excelian.mache.examples.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.examples.Example;
@@ -10,6 +11,7 @@ import java.util.Date;
 
 import static com.excelian.mache.builder.MacheBuilder.mache;
 import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandra;
+import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandraConnectionContext;
 
 /**
  * A factory for a Cassandra backed {@link Example}.
@@ -21,14 +23,15 @@ public class CassandraExample implements Example<CassandraAnnotatedMessage> {
     @Override
     public Mache<String, CassandraAnnotatedMessage> exampleCache() throws Exception {
         final String keySpace = "NoSQL_MacheClient_Test_" + DATE_FORMAT.format(new Date());
-        final Cluster cluster = Cluster.builder()
+
+        ConnectionContext<Cluster> context=cassandraConnectionContext(Cluster.builder()
                 .addContactPoint("10.28.1.140")
                 .withPort(9042)
-                .withClusterName("BluePrint").build();
+                .withClusterName("BluePrint"));
 
         return mache(String.class, CassandraAnnotatedMessage.class)
                 .backedBy(cassandra()
-                        .withCluster(cluster)
+                        .withContext(context)
                         .withKeyspace(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA).build())
                 .withNoMessaging()

--- a/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
@@ -19,17 +19,17 @@ import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandr
 public class CassandraExample implements Example<CassandraAnnotatedMessage, Cluster, CassandraAnnotatedMessage> {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
-    private String serverIpAdress;
+    private String serverIpAddress;
 
-    public CassandraExample(String serverIpAdress)
+    public CassandraExample(String serverIpAddress)
     {
-        this.serverIpAdress = serverIpAdress;
+        this.serverIpAddress = serverIpAddress;
     }
 
     public ConnectionContext<Cluster> createConnectionContext()
     {
         return cassandraConnectionContext(Cluster.builder()
-                .addContactPoint(serverIpAdress)
+                .addContactPoint(serverIpAddress)
                 .withPort(9042)
                 .withClusterName("BluePrint"));
     }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/cassandra/CassandraExample.java
@@ -19,11 +19,17 @@ import static com.excelian.mache.cassandra.builder.CassandraProvisioner.cassandr
 public class CassandraExample implements Example<CassandraAnnotatedMessage, Cluster, CassandraAnnotatedMessage> {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
+    private String serverIpAdress;
+
+    public CassandraExample(String serverIpAdress)
+    {
+        this.serverIpAdress = serverIpAdress;
+    }
 
     public ConnectionContext<Cluster> createConnectionContext()
     {
         return cassandraConnectionContext(Cluster.builder()
-                .addContactPoint("10.28.1.140")
+                .addContactPoint(serverIpAdress)
                 .withPort(9042)
                 .withClusterName("BluePrint"));
     }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseAnnotatedMessage.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseAnnotatedMessage.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples.couchbase;
 
+import com.excelian.mache.examples.Example;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.couchbase.core.mapping.Document;
 
@@ -7,7 +8,7 @@ import org.springframework.data.couchbase.core.mapping.Document;
  * Example Spring Data Couchbase Annotated Object.
  */
 @Document
-public class CouchbaseAnnotatedMessage {
+public class CouchbaseAnnotatedMessage implements Example.KeyedMessge{
 
     private final String msg;
 

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -45,6 +45,6 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Clus
 
     @Override
     public ConnectionContext<Cluster> createConnectionContext() {
-        return couchbaseConnectionContext( "10.28.1.140");
+        return couchbaseConnectionContext( "10.28.1.140", DefaultCouchbaseEnvironment.create());
     }
 }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -3,8 +3,8 @@ package com.excelian.mache.examples.couchbase;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
-import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.examples.Example;
 
 import java.text.SimpleDateFormat;
@@ -13,6 +13,7 @@ import java.util.Date;
 import static com.couchbase.client.java.cluster.DefaultBucketSettings.builder;
 import static com.excelian.mache.builder.MacheBuilder.mache;
 import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbase;
+import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbaseConnectionContext;
 
 /**
  * A factory for a Couchbase backed {@link Example}.
@@ -23,13 +24,12 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage> {
 
     @Override
     public Mache<String, CouchbaseAnnotatedMessage> exampleCache() throws Exception {
-
-        Cluster cluster = CouchbaseCluster.create(DefaultCouchbaseEnvironment.create(), "10.28.1.140");
+        ConnectionContext<Cluster> context=couchbaseConnectionContext( "10.28.1.140");
 
         final String keySpace = "NoSQL_MacheClient_Test_" + DATE_FORMAT.format(new Date());
         return mache(String.class, CouchbaseAnnotatedMessage.class)
                 .backedBy(couchbase()
-                        .withCluster(cluster)
+                        .withContext(context)
                         .withBucketSettings(builder().name(keySpace).quota(150).build())
                         .withDefaultAdminDetails()
                         .withDefaultSchemaOptions()

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -21,6 +21,12 @@ import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbas
 public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Cluster, CouchbaseAnnotatedMessage> {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
+    private String serverIpAdress;
+
+    public CouchbaseExample(String serverIpAdress)
+    {
+        this.serverIpAdress = serverIpAdress;
+    }
 
     @Override
     public Mache<String, CouchbaseAnnotatedMessage> exampleCache(ConnectionContext<Cluster> context) throws Exception {
@@ -45,6 +51,6 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Clus
 
     @Override
     public ConnectionContext<Cluster> createConnectionContext() {
-        return couchbaseConnectionContext( "10.28.1.140", DefaultCouchbaseEnvironment.create());
+        return couchbaseConnectionContext(serverIpAdress, DefaultCouchbaseEnvironment.create());
     }
 }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -23,9 +23,9 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Clus
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
     private String serverIpAdress;
 
-    public CouchbaseExample(String serverIpAdress)
+    public CouchbaseExample(String serverIpAddress)
     {
-        this.serverIpAdress = serverIpAdress;
+        this.serverIpAdress = serverIpAddress;
     }
 
     @Override

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -38,7 +38,6 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Clus
                 .backedBy(couchbase()
                         .withContext(context)
                         .withBucketSettings(builder().name(keySpace).quota(150).build())
-                        .withDefaultAdminDetails()
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())
                 .withNoMessaging()

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -18,15 +18,15 @@ import static com.excelian.mache.couchbase.builder.CouchbaseProvisioner.couchbas
 /**
  * A factory for a Couchbase backed {@link Example}.
  */
-public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage> {
+public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Cluster, CouchbaseAnnotatedMessage> {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
 
     @Override
-    public Mache<String, CouchbaseAnnotatedMessage> exampleCache() throws Exception {
-        ConnectionContext<Cluster> context=couchbaseConnectionContext( "10.28.1.140");
+    public Mache<String, CouchbaseAnnotatedMessage> exampleCache(ConnectionContext<Cluster> context) throws Exception {
 
         final String keySpace = "NoSQL_MacheClient_Test_" + DATE_FORMAT.format(new Date());
+
         return mache(String.class, CouchbaseAnnotatedMessage.class)
                 .backedBy(couchbase()
                         .withContext(context)
@@ -36,5 +36,15 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage> {
                         .build())
                 .withNoMessaging()
                 .macheUp();
+    }
+
+    @Override
+    public CouchbaseAnnotatedMessage createEntity(String primaryKey, String msg) {
+        return new CouchbaseAnnotatedMessage(primaryKey, msg);
+    }
+
+    @Override
+    public ConnectionContext<Cluster> createConnectionContext() {
+        return couchbaseConnectionContext( "10.28.1.140");
     }
 }

--- a/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/couchbase/CouchbaseExample.java
@@ -5,6 +5,7 @@ import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.env.DefaultCouchbaseEnvironment;
 import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
+import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.examples.Example;
 
 import java.text.SimpleDateFormat;
@@ -38,7 +39,7 @@ public class CouchbaseExample implements Example<CouchbaseAnnotatedMessage, Clus
                         .withContext(context)
                         .withBucketSettings(builder().name(keySpace).quota(150).build())
                         .withDefaultAdminDetails()
-                        .withDefaultSchemaOptions()
+                        .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())
                 .withNoMessaging()
                 .macheUp();

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoAnnotatedMessage.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoAnnotatedMessage.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples.mongo;
 
+import com.excelian.mache.examples.Example;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -8,7 +9,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
  * Example Spring Data Mongo Annotated Object.
  */
 @Document
-public class MongoAnnotatedMessage {
+public class MongoAnnotatedMessage implements Example.KeyedMessge{
 
     @Field
     private final String msg;

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
@@ -20,6 +20,12 @@ import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongodb;
 public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerAddress> , MongoAnnotatedMessage > {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
+    private String serverIpAdress;
+
+    public MongoExample(String serverIpAdress)
+    {
+        this.serverIpAdress = serverIpAdress;
+    }
 
     @Override
     public Mache<String, MongoAnnotatedMessage> exampleCache(ConnectionContext connectionContext) throws Exception {
@@ -36,7 +42,7 @@ public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerA
 
     @Override
     public ConnectionContext<List<ServerAddress>> createConnectionContext() {
-        return mongoConnectionContext(new ServerAddress("10.28.1.140", 9042));
+        return mongoConnectionContext(new ServerAddress(serverIpAdress, 9042));
     }
 
     @Override

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
@@ -20,11 +20,11 @@ import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongodb;
 public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerAddress> , MongoAnnotatedMessage > {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
-    private String serverIpAdress;
+    private String serverIpAddress;
 
-    public MongoExample(String serverIpAdress)
+    public MongoExample(String serverIpAddress)
     {
-        this.serverIpAdress = serverIpAdress;
+        this.serverIpAddress = serverIpAddress;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerA
 
     @Override
     public ConnectionContext<List<ServerAddress>> createConnectionContext() {
-        return mongoConnectionContext(new ServerAddress(serverIpAdress, 9042));
+        return mongoConnectionContext(new ServerAddress(serverIpAddress, 9042));
     }
 
     @Override

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.examples.mongo;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.core.SchemaOptions;
 import com.excelian.mache.examples.Example;
@@ -7,23 +8,25 @@ import com.mongodb.ServerAddress;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 import static com.excelian.mache.builder.MacheBuilder.mache;
+import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongoConnectionContext;
 import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongodb;
 
 /**
  * A factory for a Mongo backed {@link Example}.
  */
-public class MongoExample implements Example<MongoAnnotatedMessage> {
+public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerAddress> , MongoAnnotatedMessage > {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
 
     @Override
-    public Mache<String, MongoAnnotatedMessage> exampleCache() throws Exception {
+    public Mache<String, MongoAnnotatedMessage> exampleCache(ConnectionContext connectionContext) throws Exception {
         final String keySpace = "NoSQL_MacheClient_Test_" + DATE_FORMAT.format(new Date());
         return mache(String.class, MongoAnnotatedMessage.class)
                 .backedBy(mongodb()
-                        .withSeeds(new ServerAddress("10.28.1.140", 9042))
+                        .withContext(connectionContext)
                         .withDatabase(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())
@@ -31,5 +34,14 @@ public class MongoExample implements Example<MongoAnnotatedMessage> {
                 .macheUp();
     }
 
+    @Override
+    public ConnectionContext<List<ServerAddress>> createConnectionContext() {
+        return mongoConnectionContext(new ServerAddress("10.28.1.140", 9042));
+    }
+
+    @Override
+    public MongoAnnotatedMessage createEntity(String primaryKey, String msg) {
+        return new MongoAnnotatedMessage(primaryKey, msg);
+    }
 }
 

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
@@ -32,7 +32,7 @@ public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerA
         final String keySpace = "NoSQL_MacheClient_Test_" + DATE_FORMAT.format(new Date());
         return mache(String.class, MongoAnnotatedMessage.class)
                 .backedBy(mongodb()
-                        .withContext(connectionContext)
+                        .withConnectionContext(connectionContext)
                         .withDatabase(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())

--- a/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
+++ b/mache-example/src/examples/java/com/excelian/mache/examples/mongo/MongoExample.java
@@ -42,7 +42,7 @@ public class MongoExample implements Example<MongoAnnotatedMessage, List<ServerA
 
     @Override
     public ConnectionContext<List<ServerAddress>> createConnectionContext() {
-        return mongoConnectionContext(new ServerAddress(serverIpAddress, 9042));
+        return mongoConnectionContext(new ServerAddress(serverIpAddress, 27017));
     }
 
     @Override

--- a/mache-example/src/main/resources/log4j2.xml
+++ b/mache-example/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
+++ b/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
@@ -98,14 +98,6 @@ public class MongoDBCacheLoader<K, V> extends AbstractCacheLoader<K, V, MongoCli
         }
     }
 
-    @Override
-    public MongoClient getDriverSession() {
-        if (mongoClient == null) {
-            throw new IllegalStateException("Session has not been created - read/write to cache first");
-        }
-        return mongoClient;
-    }
-
     private MongoOperations ops() {
         return new MongoTemplate(mongoClient, database);
     }

--- a/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
+++ b/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
@@ -104,7 +104,7 @@ public class MongoDBCacheLoader<K, V> extends AbstractCacheLoader<K, V, MongoCli
     }
 
     private MongoClient connect() {
-        return new MongoClient(seeds.getStorage(), credentials, clientOptions);
+        return new MongoClient(seeds.getConnection(), credentials, clientOptions);
     }
 
     @Override

--- a/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
+++ b/mache-mongo/src/main/java/com/excelian/mache/mongo/MongoDBCacheLoader.java
@@ -1,5 +1,6 @@
 package com.excelian.mache.mongo;
 
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.AbstractCacheLoader;
 import com.excelian.mache.core.SchemaOptions;
 import com.mongodb.MongoClient;
@@ -23,17 +24,17 @@ public class MongoDBCacheLoader<K, V> extends AbstractCacheLoader<K, V, MongoCli
     private MongoClient mongoClient;
     private Class<K> keyType;
     private Class<V> valueType;
-    private List<ServerAddress> seeds;
+    private ConnectionContext<List<ServerAddress>> seeds;
     private SchemaOptions schemaOptions;
     private CollectionOptions collectionOptions;
     private String database;
 
-    public MongoDBCacheLoader(Class<K> keyType, Class<V> valueType, List<ServerAddress> seeds,
+    public MongoDBCacheLoader(Class<K> keyType, Class<V> valueType, ConnectionContext<List<ServerAddress>> connectionContext,
                               List<MongoCredential> credentials, MongoClientOptions clientOptions,
                               String database, SchemaOptions schemaOptions, CollectionOptions collectionOptions) {
         this.keyType = keyType;
         this.valueType = valueType;
-        this.seeds = seeds;
+        this.seeds = connectionContext;
         this.credentials = credentials;
         this.clientOptions = clientOptions;
         this.database = database;
@@ -103,7 +104,7 @@ public class MongoDBCacheLoader<K, V> extends AbstractCacheLoader<K, V, MongoCli
     }
 
     private MongoClient connect() {
-        return new MongoClient(seeds, credentials, clientOptions);
+        return new MongoClient(seeds.getStorage(), credentials, clientOptions);
     }
 
     @Override

--- a/mache-mongo/src/main/java/com/excelian/mache/mongo/builder/MongoDBProvisioner.java
+++ b/mache-mongo/src/main/java/com/excelian/mache/mongo/builder/MongoDBProvisioner.java
@@ -1,15 +1,6 @@
 package com.excelian.mache.mongo.builder;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.excelian.mache.builder.storage.ConnectionContext;
-import org.springframework.data.mongodb.core.CollectionOptions;
-
 import com.excelian.mache.builder.storage.StorageProvisioner;
 import com.excelian.mache.core.AbstractCacheLoader;
 import com.excelian.mache.core.Mache;
@@ -19,117 +10,123 @@ import com.excelian.mache.mongo.MongoDBCacheLoader;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
+import org.springframework.data.mongodb.core.CollectionOptions;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
 
 /**
  * {@link StorageProvisioner} implementation for Mongo DB.
  */
 public class MongoDBProvisioner implements StorageProvisioner {
 
-	private final ConnectionContext<List<ServerAddress>> connectionContext;
-	private final List<MongoCredential> mongoCredentials;
-	private final MongoClientOptions clientOptions;
-	private final String database;
-	private final SchemaOptions schemaOptions;
-	private final CollectionOptions collectionOptions;
+    private final ConnectionContext<List<ServerAddress>> connectionContext;
+    private final List<MongoCredential> mongoCredentials;
+    private final MongoClientOptions clientOptions;
+    private final String database;
+    private final SchemaOptions schemaOptions;
+    private final CollectionOptions collectionOptions;
 
-	private MongoDBProvisioner( ConnectionContext<List<ServerAddress>> connectionContext, List<MongoCredential> credentials,
-			MongoClientOptions clientOptions, String database, SchemaOptions schemaOptions,
-			CollectionOptions collectionOptions) {
+    private MongoDBProvisioner(ConnectionContext<List<ServerAddress>> connectionContext, List<MongoCredential> credentials,
+                               MongoClientOptions clientOptions, String database, SchemaOptions schemaOptions,
+                               CollectionOptions collectionOptions) {
 
-		this.connectionContext = connectionContext;
-		this.mongoCredentials = credentials;
-		this.clientOptions = clientOptions;
-		this.database = database;
-		this.schemaOptions = schemaOptions;
-		this.collectionOptions = collectionOptions;
-	}
+        this.connectionContext = connectionContext;
+        this.mongoCredentials = credentials;
+        this.clientOptions = clientOptions;
+        this.database = database;
+        this.schemaOptions = schemaOptions;
+        this.collectionOptions = collectionOptions;
+    }
 
-	public static ConnectionContextBuilder mongodb() {
-		return connectionContext -> database -> new MongoDBProvisionerBuilder(connectionContext, database);
-	}
+    public static ConnectionContextBuilder mongodb() {
+        return connectionContext -> database -> new MongoDBProvisionerBuilder(connectionContext, database);
+    }
 
-	@Override
-	public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
-		final MacheFactory macheFactory = new MacheFactory();
-		return macheFactory.create(getCacheLoader(keyType, valueType));
-	}
+    public static ConnectionContext<List<ServerAddress>> mongoConnectionContext(ServerAddress... seeds) {
+        return new ConnectionContext<List<ServerAddress>>() {
+            @Override
+            public List<ServerAddress> getStorage() {
+                return stream(seeds).collect(toList());
+            }
 
-	@Override
-	public <K, V> AbstractCacheLoader<K, V, ?> getCacheLoader(Class<K> keyType, Class<V> valueType) {
-		return new MongoDBCacheLoader<>(keyType, valueType, connectionContext, mongoCredentials, clientOptions, database,
-				schemaOptions, collectionOptions);
-	}
+            @Override
+            public void close() throws Exception {
+                return;
+            }
+        };
+    }
 
-	public static ConnectionContext<List<ServerAddress>> mongoConnectionContext(ServerAddress... seeds)
-	{
-		return new ConnectionContext<List<ServerAddress>>() {
-			@Override
-			public List<ServerAddress> getStorage() {
-				return stream(seeds).collect(toList());
-			}
+    @Override
+    public <K, V> Mache<K, V> getCache(Class<K> keyType, Class<V> valueType) {
+        final MacheFactory macheFactory = new MacheFactory();
+        return macheFactory.create(getCacheLoader(keyType, valueType));
+    }
 
-			@Override
-			public void close() throws Exception {
-				return;
-			}
-		};
-	}
+    @Override
+    public <K, V> AbstractCacheLoader<K, V, ?> getCacheLoader(Class<K> keyType, Class<V> valueType) {
+        return new MongoDBCacheLoader<>(keyType, valueType, connectionContext, mongoCredentials, clientOptions, database,
+                schemaOptions, collectionOptions);
+    }
 
-	/**
-	 * Forces seeds to be provided.
-	 */
-	public interface ConnectionContextBuilder {
-		DatabaseNameBuilder withContext(ConnectionContext<List<ServerAddress>> context);
-	}
+    /**
+     * Forces seeds to be provided.
+     */
+    public interface ConnectionContextBuilder {
+        DatabaseNameBuilder withContext(ConnectionContext<List<ServerAddress>> context);
+    }
 
 
-	/**
-	 * Forces database name to be provided.
-	 */
-	public interface DatabaseNameBuilder {
-		MongoDBProvisionerBuilder withDatabase(String database);
-	}
+    /**
+     * Forces database name to be provided.
+     */
+    public interface DatabaseNameBuilder {
+        MongoDBProvisionerBuilder withDatabase(String database);
+    }
 
-	/**
-	 * A builder with defaults for a Mongo DB cluster.
-	 */
-	public static class MongoDBProvisionerBuilder {
-		private final ConnectionContext<List<ServerAddress>> connectionContext;
-		private final String database;
-		private List<MongoCredential> mongoCredentials = Collections.emptyList();
-		private MongoClientOptions mongoClientOptions = MongoClientOptions.builder().build();
-		private SchemaOptions schemaOptions = SchemaOptions.USE_EXISTING_SCHEMA;
-		private CollectionOptions collectionOptions = null;
+    /**
+     * A builder with defaults for a Mongo DB cluster.
+     */
+    public static class MongoDBProvisionerBuilder {
+        private final ConnectionContext<List<ServerAddress>> connectionContext;
+        private final String database;
+        private List<MongoCredential> mongoCredentials = Collections.emptyList();
+        private MongoClientOptions mongoClientOptions = MongoClientOptions.builder().build();
+        private SchemaOptions schemaOptions = SchemaOptions.USE_EXISTING_SCHEMA;
+        private CollectionOptions collectionOptions = null;
 
-		private MongoDBProvisionerBuilder(ConnectionContext<List<ServerAddress>> connectionContext, String database) {
-			this.connectionContext = connectionContext;
-			this.database = database;
-		}
+        private MongoDBProvisionerBuilder(ConnectionContext<List<ServerAddress>> connectionContext, String database) {
+            this.connectionContext = connectionContext;
+            this.database = database;
+        }
 
-		public MongoDBProvisionerBuilder withMongoCredentials(List<MongoCredential> mongoCredentials) {
-			this.mongoCredentials = mongoCredentials;
-			return this;
-		}
+        public MongoDBProvisionerBuilder withMongoCredentials(List<MongoCredential> mongoCredentials) {
+            this.mongoCredentials = mongoCredentials;
+            return this;
+        }
 
-		public MongoDBProvisionerBuilder withMongoClientOptions(MongoClientOptions mongoClientOptions) {
-			this.mongoClientOptions = mongoClientOptions;
-			return this;
-		}
+        public MongoDBProvisionerBuilder withMongoClientOptions(MongoClientOptions mongoClientOptions) {
+            this.mongoClientOptions = mongoClientOptions;
+            return this;
+        }
 
-		public MongoDBProvisionerBuilder withSchemaOptions(SchemaOptions schemaOptions) {
-			this.schemaOptions = schemaOptions;
-			return this;
-		}
+        public MongoDBProvisionerBuilder withSchemaOptions(SchemaOptions schemaOptions) {
+            this.schemaOptions = schemaOptions;
+            return this;
+        }
 
-		public MongoDBProvisionerBuilder withCollectionOptions(CollectionOptions collectionOptions) {
-			this.collectionOptions = collectionOptions;
-			return this;
+        public MongoDBProvisionerBuilder withCollectionOptions(CollectionOptions collectionOptions) {
+            this.collectionOptions = collectionOptions;
+            return this;
 
-		}
+        }
 
-		public MongoDBProvisioner build() {
-			return new MongoDBProvisioner(connectionContext, mongoCredentials, mongoClientOptions, database, schemaOptions,
-					collectionOptions);
-		}
-	}
+        public MongoDBProvisioner build() {
+            return new MongoDBProvisioner(connectionContext, mongoCredentials, mongoClientOptions, database, schemaOptions,
+                    collectionOptions);
+        }
+    }
 }

--- a/mache-mongo/src/main/java/com/excelian/mache/mongo/builder/MongoDBProvisioner.java
+++ b/mache-mongo/src/main/java/com/excelian/mache/mongo/builder/MongoDBProvisioner.java
@@ -49,7 +49,7 @@ public class MongoDBProvisioner implements StorageProvisioner {
     public static ConnectionContext<List<ServerAddress>> mongoConnectionContext(ServerAddress... seeds) {
         return new ConnectionContext<List<ServerAddress>>() {
             @Override
-            public List<ServerAddress> getStorage() {
+            public List<ServerAddress> getConnection() {
                 return stream(seeds).collect(toList());
             }
 
@@ -76,7 +76,7 @@ public class MongoDBProvisioner implements StorageProvisioner {
      * Forces seeds to be provided.
      */
     public interface ConnectionContextBuilder {
-        DatabaseNameBuilder withContext(ConnectionContext<List<ServerAddress>> context);
+        DatabaseNameBuilder withConnectionContext(ConnectionContext<List<ServerAddress>> context);
     }
 
 

--- a/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
+++ b/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
@@ -62,6 +62,7 @@ public class MongoCacheIntegrationTest {
     }
 
     @Test
+    @IgnoreIf(condition = NoRunningMongoDbForTests.class)
     public void testPut() throws Exception {
         mache.put("test-1", new TestEntity("test-1"));
         TestEntity test = mache.get("test-1");

--- a/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
+++ b/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
@@ -53,16 +53,7 @@ public class MongoCacheIntegrationTest {
     public void tearDown() throws Exception {
         mache.close();
     }
-
-    @Test
-    public void testGetDriver() throws Exception {
-        mache.put("test-1", new TestEntity("test-1"));
-        mache.get("test-1");
-        MongoDBCacheLoader cacheLoader = (MongoDBCacheLoader) mache.getCacheLoader();
-        Mongo driver = cacheLoader.getDriverSession();
-        assertNotNull(driver.getAddress());
-    }
-
+    
     @Test
     public void testPut() throws Exception {
         mache.put("test-1", new TestEntity("test-1"));

--- a/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
+++ b/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
@@ -2,10 +2,10 @@ package com.excelian.mache.mongo;
 
 import com.codeaffine.test.ConditionalIgnoreRule;
 import com.excelian.mache.builder.MacheBuilder;
+import com.excelian.mache.builder.storage.ConnectionContext;
 import com.excelian.mache.core.Mache;
 import com.excelian.mache.core.SchemaOptions;
 import com.google.common.cache.CacheLoader;
-import com.mongodb.Mongo;
 import com.mongodb.ServerAddress;
 import org.junit.After;
 import org.junit.Before;
@@ -17,8 +17,10 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.Date;
+import java.util.List;
 
 import static com.codeaffine.test.ConditionalIgnoreRule.IgnoreIf;
+import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongoConnectionContext;
 import static com.excelian.mache.mongo.builder.MongoDBProvisioner.mongodb;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,17 +33,21 @@ public class MongoCacheIntegrationTest {
 
 
     private String keySpace = "NoSQL_Nearside_Test_" + new Date().toString();
+
     private Mache<String, TestEntity> mache;
+    private ConnectionContext<List<ServerAddress>> connectionContext;
 
     @Before
     public void setUp() throws Exception {
-        mache = getMache();
+        connectionContext = mongoConnectionContext(new ServerAddress(new NoRunningMongoDbForTests().getHost(), 27017));
+        mache = getMache(connectionContext);
     }
 
-    private Mache<String, TestEntity> getMache() throws Exception {
+    private Mache<String, TestEntity> getMache(ConnectionContext<List<ServerAddress>> context) throws Exception {
+
         return MacheBuilder.mache(String.class, TestEntity.class)
                 .backedBy(mongodb()
-                        .withSeeds(new ServerAddress(new NoRunningMongoDbForTests().getHost(), 27017))
+                        .withContext(context)
                         .withDatabase(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())
@@ -52,8 +58,9 @@ public class MongoCacheIntegrationTest {
     @After
     public void tearDown() throws Exception {
         mache.close();
+        connectionContext.close();
     }
-    
+
     @Test
     public void testPut() throws Exception {
         mache.put("test-1", new TestEntity("test-1"));
@@ -86,33 +93,32 @@ public class MongoCacheIntegrationTest {
 
     @Test
     public void testInvalidate() throws Exception {
-        final Mache<String, TestEntity> mache = getMache();
+        try(final Mache<String, TestEntity> anotherMache = getMache(connectionContext)) {
 
-        final String key = "test-1";
-        final String expectedDescription = "test1-description";
-        this.mache.put(key, new TestEntity(key, expectedDescription));
-        assertEquals(expectedDescription, this.mache.get(key).getaString());
-        assertEquals(expectedDescription, mache.get(key).getaString());
+            final String key = "test-1";
+            final String expectedDescription = "test1-description";
+            this.mache.put(key, new TestEntity(key, expectedDescription));
+            assertEquals(expectedDescription, this.mache.get(key).getaString());
+            assertEquals(expectedDescription, anotherMache.get(key).getaString());
 
-        final String expectedDescription2 = "test-description2";
-        mache.put(key, new TestEntity(key, expectedDescription2));
-        this.mache.invalidate(key);
-        assertEquals(expectedDescription2, this.mache.get(key).getaString());
-        assertEquals(expectedDescription2, mache.get(key).getaString());
-
-        mache.close();
+            final String expectedDescription2 = "test-description2";
+            anotherMache.put(key, new TestEntity(key, expectedDescription2));
+            this.mache.invalidate(key);
+            assertEquals(expectedDescription2, this.mache.get(key).getaString());
+            assertEquals(expectedDescription2, anotherMache.get(key).getaString());
+        }
     }
 
     @Test
     public void testReadThrough() throws Exception {
         this.mache.put("test-2", new TestEntity("test-2"));
         this.mache.put("test-3", new TestEntity("test-3"));
-        Mache<String, TestEntity> mache = getMache();
 
-        TestEntity test = mache.get("test-2");
-        assertEquals("test-2", test.pkString);
+        try(Mache<String, TestEntity> anotherMacheInstance = getMache(connectionContext)) {
 
-        mache.close();
+            TestEntity test = anotherMacheInstance.get("test-2");
+            assertEquals("test-2", test.pkString);
+        }
     }
 
     /**

--- a/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
+++ b/mache-mongo/src/test/java/com/excelian/mache/mongo/MongoCacheIntegrationTest.java
@@ -47,7 +47,7 @@ public class MongoCacheIntegrationTest {
 
         return MacheBuilder.mache(String.class, TestEntity.class)
                 .backedBy(mongodb()
-                        .withContext(context)
+                        .withConnectionContext(context)
                         .withDatabase(keySpace)
                         .withSchemaOptions(SchemaOptions.CREATE_AND_DROP_SCHEMA)
                         .build())


### PR DESCRIPTION
- Storage Provisioners now share a connection context - this is necessary for Cassandra and Mache so the life cycle is handled separately and closed().
- Fixed the examples putting data into 3 storages and now include their execution as part of **travis**
- Fixed Couch example - didn't create schema
- Fixed Mongo example - didn't use correct port
- Fixed cassandra example - wrong jar version and conflict with ActiveMQ imports.
- Fixed cassandra example hanging - now closes cluster (as part of ConnectionContext)
